### PR TITLE
Move sidechain handling to decorator

### DIFF
--- a/scripts/wait_for_truffle.sh
+++ b/scripts/wait_for_truffle.sh
@@ -32,7 +32,7 @@ done
 
 shift $(expr $OPTIND - 1 )
 cmd="$@"
-echo "gonna run"
+printf "gonna run"
 echo $cmd
 exec $cmd
 

--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -14,7 +14,7 @@ if require_api_key:
     from polyswarmd.db import init_db, db_session, lookup_api_key, add_api_key
     init_db()
 
-from polyswarmd.eth import misc, web3
+from polyswarmd.eth import misc
 from polyswarmd.response import success, failure, install_error_handlers
 from polyswarmd.utils import bool_list_to_int, int_to_bool_list
 from polyswarmd.artifacts import artifacts

--- a/src/polyswarmd/balances.py
+++ b/src/polyswarmd/balances.py
@@ -1,13 +1,13 @@
 from flask import Blueprint, request, g
 
-from polyswarmd.chains import select_chain
+from polyswarmd.chains import chain
 from polyswarmd.response import success, failure
 
 balances = Blueprint('balances', __name__)
 
 
 @balances.route('/<address>/eth', methods=['GET'])
-@select_chain
+@chain
 def get_balance_address_eth(address):
     if not g.web3.isAddress(address):
         return failure('Invalid address', 400)
@@ -20,7 +20,7 @@ def get_balance_address_eth(address):
         return failure("Could not retrieve balance")
 
 @balances.route('/<address>/staking/total', methods=['GET'])
-@select_chain
+@chain
 def get_balance_total_stake(address):
     if not g.web3.isAddress(address):
         return failure('Invalid address', 400)
@@ -33,7 +33,7 @@ def get_balance_total_stake(address):
 
 
 @balances.route('/<address>/staking/withdrawable', methods=['GET'])
-@select_chain
+@chain
 def get_balance_withdrawable_stake(address):
     if not g.web3.isAddress(address):
         return failure('Invalid address', 400)
@@ -47,7 +47,7 @@ def get_balance_withdrawable_stake(address):
 
 
 @balances.route('/<address>/nct', methods=['GET'])
-@select_chain
+@chain
 def get_balance_address_nct(address):
     if not g.web3.isAddress(address):
         return failure('Invalid address', 400)

--- a/src/polyswarmd/balances.py
+++ b/src/polyswarmd/balances.py
@@ -1,91 +1,60 @@
-from flask import Blueprint, request
+from flask import Blueprint, request, g
 
-from polyswarmd.eth import web3 as web3_chains, nectar_token as nectar_chains, arbiter_staking as arbiter_chains
+from polyswarmd.chains import select_chain
 from polyswarmd.response import success, failure
 
 balances = Blueprint('balances', __name__)
 
 
 @balances.route('/<address>/eth', methods=['GET'])
+@select_chain
 def get_balance_address_eth(address):
-    chain = request.args.get('chain')
-    if not chain:
-        chain = 'home'
-    elif chain != 'side' and chain != 'home':
-        return failure('Chain must be either home or side', 400)
-
-    web3 = web3_chains[chain]
-
-    if not web3.isAddress(address):
+    if not g.web3.isAddress(address):
         return failure('Invalid address', 400)
 
-    address = web3.toChecksumAddress(address)
+    address = g.web3.toChecksumAddress(address)
     try:
-        balance = web3.eth.getBalance(address)
+        balance = g.web3.eth.getBalance(address)
         return success(str(balance))
     except:
         return failure("Could not retrieve balance")
 
 @balances.route('/<address>/staking/total', methods=['GET'])
+@select_chain
 def get_balance_total_stake(address):
-    chain = request.args.get('chain')
-    if not chain:
-        chain = 'home'
-    elif chain != 'side' and chain != 'home':
-        return failure('Chain must be either home or side', 400)
-
-    web3 = web3_chains[chain]
-    arbiter_staking = arbiter_chains[chain]
-
-    if not web3.isAddress(address):
+    if not g.web3.isAddress(address):
         return failure('Invalid address', 400)
-    address = web3.toChecksumAddress(address)
+    address = g.web3.toChecksumAddress(address)
     try:
-        balance = arbiter_staking.functions.balanceOf(address).call()
+        balance = g.arbiter_staking.functions.balanceOf(address).call()
         return success(str(balance))
     except:
         return failure("Could not retrieve balance")
 
 
 @balances.route('/<address>/staking/withdrawable', methods=['GET'])
+@select_chain
 def get_balance_withdrawable_stake(address):
-    chain = request.args.get('chain')
-    if not chain:
-        chain = 'home'
-    elif chain != 'side' and chain != 'home':
-        return failure('Chain must be either home or side', 400)
-
-    web3 = web3_chains[chain]
-    arbiter_staking = arbiter_chains[chain]
-
-    if not web3.isAddress(address):
+    if not g.web3.isAddress(address):
         return failure('Invalid address', 400)
 
-    address = web3.toChecksumAddress(address)
+    address = g.web3.toChecksumAddress(address)
     try:
-        balance = arbiter_staking.functions.withdrawableBalanceOf(address).call()
+        balance = g.arbiter_staking.functions.withdrawableBalanceOf(address).call()
         return success(str(balance))
     except:
         return failure("Could not retrieve balance")
 
 
 @balances.route('/<address>/nct', methods=['GET'])
+@select_chain
 def get_balance_address_nct(address):
-    chain = request.args.get('chain')
-    if not chain:
-        chain = 'home'
-    elif chain != 'side' and chain != 'home':
-        return failure('Chain must be either home or side', 400)
-
-    web3 = web3_chains[chain]
-    nectar_token = nectar_chains[chain]
-
-    if not web3.isAddress(address):
+    if not g.web3.isAddress(address):
         return failure('Invalid address', 400)
 
-    address = web3.toChecksumAddress(address)
+    address = g.web3.toChecksumAddress(address)
     try:
-        balance = nectar_token.functions.balanceOf(address).call()
+        balance = g.nectar_token.functions.balanceOf(address).call()
         return success(str(balance))
     except:
         return failure("Could not retrieve balance")

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -8,7 +8,7 @@ from jsonschema.exceptions import ValidationError
 
 from polyswarmd import eth
 from polyswarmd.artifacts import is_valid_ipfshash, list_artifacts
-from polyswarmd.chains import select_chain
+from polyswarmd.chains import chain
 from polyswarmd.bloom import BloomFilter, FILTER_BITS
 from polyswarmd.eth import build_transaction, zero_address
 from polyswarmd.response import success, failure
@@ -49,7 +49,7 @@ def calculate_commitment(account, verdicts):
 
 
 @bounties.route('', methods=['POST'])
-@select_chain
+@chain
 def post_bounties():
     account = g.web3.toChecksumAddress(g.eth_address)
 
@@ -119,21 +119,21 @@ def post_bounties():
 
 
 @bounties.route('/window/reveal', methods=['GET'])
-@select_chain
+@chain
 def get_bounty_reveal_window():
     assertion_reveal_window = g.bounty_registry.functions.ASSERTION_REVEAL_WINDOW().call()
 
     return success({'blocks': assertion_reveal_window})
 
 @bounties.route('/window/vote', methods=['GET'])
-@select_chain
+@chain
 def get_bounty_vote_window():
     assertion_vote_window = g.bounty_registry.functions.arbiterVoteWindow().call()
 
     return success({'blocks': assertion_vote_window})
 
 @bounties.route('/<uuid:guid>', methods=['GET'])
-@select_chain
+@chain
 def get_bounties_guid(guid):
     bounty = bounty_to_dict(
         g.bounty_registry.functions.bountiesByGuid(guid.int).call())
@@ -146,7 +146,7 @@ def get_bounties_guid(guid):
 
 
 @bounties.route('/<uuid:guid>/vote', methods=['POST'])
-@select_chain
+@chain
 def post_bounties_guid_vote(guid):
     account = g.web3.toChecksumAddress(g.eth_address)
 
@@ -188,7 +188,7 @@ def post_bounties_guid_vote(guid):
 
 
 @bounties.route('/<uuid:guid>/settle', methods=['POST'])
-@select_chain
+@chain
 def post_bounties_guid_settle(guid):
     account = g.web3.toChecksumAddress(g.eth_address)
 
@@ -204,7 +204,7 @@ def post_bounties_guid_settle(guid):
 
 
 @bounties.route('/<uuid:guid>/assertions', methods=['POST'])
-@select_chain
+@chain
 def post_bounties_guid_assertions(guid):
     account = g.web3.toChecksumAddress(g.eth_address)
 
@@ -268,7 +268,7 @@ def post_bounties_guid_assertions(guid):
 
 
 @bounties.route('/<uuid:guid>/assertions/<int:id_>/reveal', methods=['POST'])
-@select_chain
+@chain
 def post_bounties_guid_assertions_id_reveal(guid, id_):
     account = g.web3.toChecksumAddress(g.eth_address)
 
@@ -318,7 +318,7 @@ def post_bounties_guid_assertions_id_reveal(guid, id_):
 
 
 @bounties.route('/<uuid:guid>/assertions', methods=['GET'])
-@select_chain
+@chain
 def get_bounties_guid_assertions(guid):
     num_assertions = g.bounty_registry.functions.getNumberOfAssertions(
         guid.int).call()
@@ -332,7 +332,7 @@ def get_bounties_guid_assertions(guid):
 
 
 @bounties.route('/<uuid:guid>/assertions/<int:id_>', methods=['GET'])
-@select_chain
+@chain
 def get_bounties_guid_assertions_id(guid, id_):
     try:
         return success(

--- a/src/polyswarmd/chains.py
+++ b/src/polyswarmd/chains.py
@@ -47,13 +47,13 @@ for chain in ('home', 'side'):
             os.path.join(config_location, 'contracts', 'ArbiterStaking.json'))
 
         if chain == 'home':
-            offer_registry = bind_contract(
+            offer_registry_home = bind_contract(
                 web3, offer_registry_address[chain],
                 os.path.join(config_location, 'contracts', 'OfferRegistry.json'))
 
-            offer_lib_address = offer_registry.functions.offerLib().call()
+            offer_lib_address = offer_registry_home.functions.offerLib().call()
 
-            offer_lib = bind_contract(
+            offer_lib_home = bind_contract(
                 web3, offer_lib_address,
                 os.path.join(config_location, 'contracts', 'OfferLib.json'))
 

--- a/src/polyswarmd/chains.py
+++ b/src/polyswarmd/chains.py
@@ -57,7 +57,7 @@ for chain in ('home', 'side'):
                 web3, offer_lib_address,
                 os.path.join(config_location, 'contracts', 'OfferLib.json'))
 
-def select_chain(_func=None, *, chain_name=None):
+def chain(_func=None, *, chain_name=None):
     """This decorator takes the chain passed as a request arg and modifies a set of globals.
        There are a few guarantees made by this function.
 

--- a/src/polyswarmd/chains.py
+++ b/src/polyswarmd/chains.py
@@ -1,0 +1,127 @@
+import functools
+import os
+
+from flask import g, request
+
+from web3 import Web3, HTTPProvider
+from web3.middleware import geth_poa_middleware
+
+from polyswarmd.response import failure
+from polyswarmd.config import config_location, chain_id as id_chains, eth_uri as eth_chains, nectar_token_address as nectar_chains, bounty_registry_address as bounty_chains, offer_registry_address, free as free_chains, erc20_relay_address as erc20_relay_chains
+from polyswarmd.eth import bind_contract
+
+web3_chains = {}
+# Create token bindings for each chain
+bounty_registry_chains = {}
+nectar_token_chains = {}
+arbiter_staking_chains = {}
+
+# exists only on home
+offer_registry_home = None
+offer_lib_home = None
+
+for chain in ('home', 'side'):
+    # Grab all the values for the chain. If they aren't defined, skip
+    eth_uri = eth_chains.get(chain)
+    bounty_registry_address = bounty_chains.get(chain)
+    nectar_token_address = nectar_chains.get(chain)
+
+    if (
+            eth_uri is not None
+            and bounty_registry_address is not None
+            and nectar_token_address is not None
+        ):
+
+        web3 = Web3(HTTPProvider(eth_uri))
+        web3.middleware_stack.inject(geth_poa_middleware, layer=0)
+        web3_chains[chain] = web3
+        nectar_token_chains[chain] = bind_contract(
+            web3, nectar_token_address,
+            os.path.join(config_location, 'contracts', 'NectarToken.json'))
+
+        bounty_registry_chains[chain] = bind_contract(
+            web3, bounty_registry_address,
+            os.path.join(config_location, 'contracts', 'BountyRegistry.json'))
+        arbiter_staking_chains[chain] = bind_contract(
+            web3, bounty_registry_chains[chain].functions.staking().call(),
+            os.path.join(config_location, 'contracts', 'ArbiterStaking.json'))
+
+        if chain == 'home':
+            offer_registry = bind_contract(
+                web3, offer_registry_address[chain],
+                os.path.join(config_location, 'contracts', 'OfferRegistry.json'))
+
+            offer_lib_address = offer_registry.functions.offerLib().call()
+
+            offer_lib = bind_contract(
+                web3, offer_lib_address,
+                os.path.join(config_location, 'contracts', 'OfferLib.json'))
+
+def select_chain(_func=None, *, chain_name=None):
+    """This decorator takes the chain passed as a request arg and modifies a set of globals.
+       There are a few guarantees made by this function.
+
+       If any of the values for the given chain are missing, the decorator will skip the function and return an error to the user. (500)
+       If the chain is not recognized, it will return an error to the user. (400)
+       If it is the home chain, the offer contract address and  bindings will also be validated, or an error returned. (500)
+    """
+    @functools.wraps(_func)
+    def decorator_wrapper(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            nonlocal chain_name
+            if chain_name is None:
+                chain_name = request.args.get('chain', 'home')
+
+            if chain_name != "home" and chain_name != "side":
+                return failure('Chain must be either home or side', 400)
+
+            if chain_name == "side" and chain_name not in nectar_chains.keys():
+                return failure('Side chain not supported in this instance of polyswarmd', 400)
+
+            chain_data = {
+                "chain_id": id_chains.get(chain_name),
+                "nectar_token_address": nectar_chains.get(chain_name),
+                "bounty_registry_address": bounty_chains.get(chain_name),
+                "erc20_relay_address": erc20_relay_chains.get(chain_name),
+                "eth_uri": eth_chains.get(chain_name),
+                "free": free_chains.get(chain_name),
+                "bounty_registry": bounty_registry_chains.get(chain_name),
+                "nectar_token": nectar_token_chains.get(chain_name),
+                "arbiter_staking": arbiter_staking_chains.get(chain_name),
+                "web3": web3_chains.get(chain_name),
+            }
+            if chain_name == "home":
+                chain_data["offer_lib"] = offer_lib_home
+                chain_data["offer_registry"] = offer_registry_home
+
+
+            if validate(chain_data):
+                # Add all validated fields to g
+                for k, v in chain_data.items():
+                    g.setdefault(k, default=v)
+
+                # Add these if not defined (which means we are not on the home chain, because that is already validated)
+                if not g.get('offer_lib'):
+                    g.offer_lib = None
+
+                if not g.get('offer_registry'):
+                    g.offer_registry = None
+
+                return func(*args, **kwargs)
+            else:
+                return failure("Server experienced an error finding %s chain values" % chain_name, 500)
+        return wrapper
+
+    if _func is None:
+        return decorator_wrapper
+    else:
+        return decorator_wrapper(_func)
+
+
+def validate(chain_data):
+    for v in chain_data:
+        if v is None:
+            return False
+
+    return True

--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -69,7 +69,7 @@ def init_config():
             offer_registry_address['home'] = home.get(
                 'offer_registry_address')  # only on home chain
             chain_id['home'] = home.get('chain_id')
-            free["home"] = home.get('free', False)
+            free['home'] = home.get('free', False)
 
         side = y.get('sidechain')
         if side is not None:
@@ -78,7 +78,7 @@ def init_config():
             bounty_registry_address['side'] = side.get('bounty_registry_address')
             erc20_relay_address['side'] = side.get('erc20_relay_address')
             chain_id['side'] = side.get('chain_id')
-            free["side"] = side.get('free', False)
+            free['side'] = side.get('free', False)
 
 
 def set_config(**kwargs):

--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -60,23 +60,25 @@ def init_config():
         if db_uri is not None:
             require_api_key = True
 
-        home = y['homechain']
-        eth_uri['home'] = home['eth_uri']
-        nectar_token_address['home'] = home['nectar_token_address']
-        bounty_registry_address['home'] = home['bounty_registry_address']
-        erc20_relay_address['home'] = home['erc20_relay_address']
-        offer_registry_address['home'] = home[
-            'offer_registry_address']  # only on home chain
-        chain_id['home'] = home['chain_id']
-        free["home"] = home.get('free', False)
+        home = y.get('homechain')
+        if home is not None:
+            eth_uri['home'] = home.get('eth_uri')
+            nectar_token_address['home'] = home.get('nectar_token_address')
+            bounty_registry_address['home'] = home.get('bounty_registry_address')
+            erc20_relay_address['home'] = home.get('erc20_relay_address')
+            offer_registry_address['home'] = home.get(
+                'offer_registry_address')  # only on home chain
+            chain_id['home'] = home.get('chain_id')
+            free["home"] = home.get('free', False)
 
-        side = y['sidechain']
-        eth_uri['side'] = side['eth_uri']
-        nectar_token_address['side'] = side['nectar_token_address']
-        bounty_registry_address['side'] = side['bounty_registry_address']
-        erc20_relay_address['side'] = side['erc20_relay_address']
-        chain_id['side'] = side['chain_id']
-        free["side"] = side.get('free', False)
+        side = y.get('sidechain')
+        if side is not None:
+            eth_uri['side'] = side.get('eth_uri')
+            nectar_token_address['side'] = side.get('nectar_token_address')
+            bounty_registry_address['side'] = side.get('bounty_registry_address')
+            erc20_relay_address['side'] = side.get('erc20_relay_address')
+            chain_id['side'] = side.get('chain_id')
+            free["side"] = side.get('free', False)
 
 
 def set_config(**kwargs):

--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -35,10 +35,10 @@ zero_address = '0x0000000000000000000000000000000000000000'
 offer_msig_artifact = os.path.join(config_location, 'contracts',
                                    'OfferMultiSig.json')
 
-from polyswarmd.chains import select_chain
+from polyswarmd.chains import chain
 
 @misc.route('/syncing', methods=['GET'])
-@select_chain
+@chain
 def get_syncing():
     if not g.web3.eth.syncing:
         return success(False)
@@ -47,7 +47,7 @@ def get_syncing():
 
 
 @misc.route('/nonce', methods=['GET'])
-@select_chain
+@chain
 def get_nonce():
     account = g.web3.toChecksumAddress(g.eth_address)
 
@@ -55,7 +55,7 @@ def get_nonce():
 
 
 @misc.route('/transactions', methods=['POST'])
-@select_chain
+@chain
 def post_transactions():
     account = g.web3.toChecksumAddress(g.eth_address)
 

--- a/src/polyswarmd/offers.py
+++ b/src/polyswarmd/offers.py
@@ -154,7 +154,7 @@ def post_open(guid):
 
     transactions = [
         build_transaction(
-            g.nectar_token['home'].functions.approve(
+            g.nectar_token.functions.approve(
                 msig_address, approve_amount),  base_nonce),
         build_transaction(
             offer_msig.functions.openAgreement(to_padded_hex(state), v, to_padded_hex(r), to_padded_hex(s)),

--- a/src/polyswarmd/offers.py
+++ b/src/polyswarmd/offers.py
@@ -3,17 +3,16 @@ import json
 import jsonschema
 from jsonschema.exceptions import ValidationError
 from flask import Blueprint, g, request
-from polyswarmd.chains import select_chain
+from polyswarmd.chains import chain
 from polyswarmd.eth import build_transaction, offer_msig_artifact, bind_contract
 from polyswarmd.response import success, failure
 from polyswarmd.utils import channel_to_dict, validate_ws_url, dict_to_state, to_padded_hex, bool_list_to_int
 
-chain = 'home'  # only on home chain
 offers = Blueprint('offers', __name__)
 
 
 @offers.route('', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def post_create_offer_channel():
     account = g.web3.toChecksumAddress(g.eth_address)
 
@@ -62,7 +61,7 @@ def post_create_offer_channel():
 
 
 @offers.route('/<uuid:guid>/uri', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def post_uri(guid):
     offer_channel = channel_to_dict(
         g.offer_registry.functions.guidToChannel(guid.int).call())
@@ -105,7 +104,7 @@ def post_uri(guid):
 
 
 @offers.route('/<uuid:guid>/open', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def post_open(guid):
     offer_channel = channel_to_dict(
         g.offer_registry.functions.guidToChannel(guid.int).call())
@@ -166,7 +165,7 @@ def post_open(guid):
 
 
 @offers.route('/<uuid:guid>/cancel', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def post_cancel(guid):
     offer_channel = channel_to_dict(
         g.offer_registry.functions.guidToChannel(guid.int).call())
@@ -185,7 +184,7 @@ def post_cancel(guid):
 
 
 @offers.route('/<uuid:guid>/join', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def post_join(guid):
     offer_channel = channel_to_dict(
         g.offer_registry.functions.guidToChannel(guid.int).call())
@@ -241,7 +240,7 @@ def post_join(guid):
 
 
 @offers.route('/<uuid:guid>/close', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def post_close(guid):
     offer_channel = channel_to_dict(
         g.offer_registry.functions.guidToChannel(guid.int).call())
@@ -301,7 +300,7 @@ def post_close(guid):
 
 # for closing a challenged state with a timeout
 @offers.route('/<uuid:guid>/closeChallenged', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def post_close_challenged(guid):
     offer_channel = channel_to_dict(
         g.offer_registry.functions.guidToChannel(guid.int).call())
@@ -360,7 +359,7 @@ def post_close_challenged(guid):
 
 
 @offers.route('/<uuid:guid>/settle', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def post_settle(guid):
     offer_channel = channel_to_dict(
         g.offer_registry.functions.guidToChannel(guid.int).call())
@@ -419,7 +418,7 @@ def post_settle(guid):
 
 
 @offers.route('/state', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def create_state():
 
     body = request.get_json()
@@ -523,7 +522,7 @@ def create_state():
 
 
 @offers.route('/<uuid:guid>/challenge', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def post_challange(guid):
     offer_channel = channel_to_dict(
         g.offer_registry.functions.guidToChannel(guid.int).call())
@@ -581,7 +580,7 @@ def post_challange(guid):
     return success({'transactions': transactions})
 
 @offers.route('/<uuid:guid>', methods=['GET'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def get_channel_address(guid):
     offer_channel = g.offer_registry.functions.guidToChannel(guid.int).call()
 
@@ -589,7 +588,7 @@ def get_channel_address(guid):
 
 
 @offers.route('/<uuid:guid>/settlementPeriod', methods=['GET'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def get_settlement_period(guid):
     offer_channel = g.offer_registry.functions.guidToChannel(guid.int).call()
     channel_data = channel_to_dict(offer_channel)
@@ -602,7 +601,7 @@ def get_settlement_period(guid):
 
 
 @offers.route('/<uuid:guid>/websocket', methods=['GET'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def get_websocket(guid):
     offer_channel = g.offer_registry.functions.guidToChannel(guid.int).call()
     channel_data = channel_to_dict(offer_channel)
@@ -621,7 +620,7 @@ def get_websocket(guid):
 
 
 @offers.route('pending', methods=['GET'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def get_pending():
     offers_pending = []
     num_of_offers = g.offer_registry.functions.getNumberOfOffers().call()
@@ -640,7 +639,7 @@ def get_pending():
 
 
 @offers.route('opened', methods=['GET'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def get_opened():
     offers_opened = []
     num_of_offers = g.offer_registry.functions.getNumberOfOffers().call()
@@ -659,7 +658,7 @@ def get_opened():
 
 
 @offers.route('closed', methods=['GET'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def get_closed():
     offers_closed = []
     num_of_offers = g.offer_registry.functions.getNumberOfOffers().call()
@@ -678,7 +677,7 @@ def get_closed():
 
 
 @offers.route('myoffers', methods=['GET'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def get_myoffers():
     account = g.web3.toChecksumAddress(g.eth_address)
 

--- a/src/polyswarmd/relay.py
+++ b/src/polyswarmd/relay.py
@@ -4,20 +4,20 @@ from jsonschema.exceptions import ValidationError
 from flask import Blueprint, g, request
 
 from polyswarmd.response import success, failure
-from polyswarmd.chains import select_chain
+from polyswarmd.chains import chain
 from polyswarmd.eth import build_transaction
 
 relay = Blueprint('relay', __name__)
 
 @relay.route('/deposit', methods=['POST'])
-@select_chain(chain_name='home')
+@chain(chain_name='home')
 def deposit_funds():
     # Move funds from home to side
     return send_funds_from()
 
 
 @relay.route('/withdrawal', methods=['POST'])
-@select_chain(chain_name='side')
+@chain(chain_name='side')
 def withdraw_funds():
     # Move funds from side to home
     return send_funds_from()

--- a/src/polyswarmd/staking.py
+++ b/src/polyswarmd/staking.py
@@ -4,14 +4,14 @@ from flask import Blueprint, g, request
 
 from polyswarmd import eth
 from polyswarmd.eth import build_transaction
-from polyswarmd.chains import select_chain
+from polyswarmd.chains import chain
 from polyswarmd.response import success, failure
 
 staking = Blueprint('staking', __name__)
 
 
 @staking.route('/deposit', methods=['POST'])
-@select_chain
+@chain
 def post_arbiter_staking_deposit():
     account = g.web3.toChecksumAddress(g.eth_address)
 
@@ -55,7 +55,7 @@ def post_arbiter_staking_deposit():
 
 
 @staking.route('/withdraw', methods=['POST'])
-@select_chain
+@chain
 def post_arbiter_staking_withdrawal():
     account = g.web3.toChecksumAddress(g.eth_address)
 

--- a/src/polyswarmd/staking.py
+++ b/src/polyswarmd/staking.py
@@ -3,26 +3,20 @@ from jsonschema.exceptions import ValidationError
 from flask import Blueprint, g, request
 
 from polyswarmd import eth
-from polyswarmd.eth import web3 as web3_chains, build_transaction, nectar_token as nectar_chains, arbiter_staking as arbiter_chains
+from polyswarmd.eth import build_transaction
+from polyswarmd.chains import select_chain
 from polyswarmd.response import success, failure
 
 staking = Blueprint('staking', __name__)
 
 
 @staking.route('/deposit', methods=['POST'])
+@select_chain
 def post_arbiter_staking_deposit():
-    # Must read chain before account to have a valid web3 ref
-    chain = request.args.get('chain', 'home')
-    if chain != 'side' and chain != 'home':
-        return failure('Chain must be either home or side', 400)
-
-    web3 = web3_chains[chain]
-    nectar_token = nectar_chains[chain]
-    arbiter_staking = arbiter_chains[chain]
-    account = web3.toChecksumAddress(g.eth_address)
+    account = g.web3.toChecksumAddress(g.eth_address)
 
     base_nonce = int(
-        request.args.get('base_nonce', web3.eth.getTransactionCount(account)))
+        request.args.get('base_nonce', g.web3.eth.getTransactionCount(account)))
 
     schema = {
         'type': 'object',
@@ -45,34 +39,28 @@ def post_arbiter_staking_deposit():
 
     amount = int(body['amount'])
 
-    total = arbiter_staking.functions.balanceOf(account).call()
+    total = g.arbiter_staking.functions.balanceOf(account).call()
 
-    if amount + total >= eth.staking_total_max(chain):
+    if amount + total >= eth.staking_total_max(g.arbiter_staking):
         return failure('Total stake above allowable maximum.', 400)
 
     transactions = [
         build_transaction(
-            nectar_token.functions.approve(arbiter_staking.address, amount), chain, base_nonce),
+            g.nectar_token.functions.approve(g.arbiter_staking.address, amount), base_nonce),
         build_transaction(
-            arbiter_staking.functions.deposit(amount), chain, base_nonce + 1),
+            g.arbiter_staking.functions.deposit(amount),  base_nonce + 1),
     ]
 
     return success({'transactions': transactions})
 
 
 @staking.route('/withdraw', methods=['POST'])
+@select_chain
 def post_arbiter_staking_withdrawal():
-    # Must read chain before account to have a valid web3 ref
-    chain = request.args.get('chain', 'home')
-    if chain != 'side' and chain != 'home':
-        return failure('Chain must be either home or side', 400)
-
-    web3 = web3_chains[chain]
-    arbiter_staking = arbiter_chains[chain]
-    account = web3.toChecksumAddress(g.eth_address)
+    account = g.web3.toChecksumAddress(g.eth_address)
 
     base_nonce = int(
-        request.args.get('base_nonce', web3.eth.getTransactionCount(account)))
+        request.args.get('base_nonce', g.web3.eth.getTransactionCount(account)))
 
     schema = {
         'type': 'object',
@@ -95,14 +83,14 @@ def post_arbiter_staking_withdrawal():
 
     amount = int(body['amount'])
 
-    available = arbiter_staking.functions.withdrawableBalanceOf(account).call()
+    available = g.arbiter_staking.functions.withdrawableBalanceOf(account).call()
 
     if amount > available:
         return failure('Exceeds withdrawal eligible %s' % available, 400)
 
     transactions = [
         build_transaction(
-            arbiter_staking.functions.withdraw(amount), chain, base_nonce),
+            g.arbiter_staking.functions.withdraw(amount), base_nonce),
     ]
 
     return success({'transactions': transactions})

--- a/src/polyswarmd/utils.py
+++ b/src/polyswarmd/utils.py
@@ -1,6 +1,7 @@
 import re
 import uuid
-from polyswarmd.eth import offer_lib, web3 as web3_chains, zero_address
+from flask import g
+from polyswarmd.eth import zero_address
 
 def bool_list_to_int(bs):
     return sum([1 << n if b else 0 for n, b in enumerate(bs)])
@@ -130,21 +131,20 @@ def channel_to_dict(channel_data):
 
 def state_to_dict(state):
     # gets state of non required state
-    offer_info = offer_lib.functions.getOfferState(state).call()
-    web3 = web3_chains['home']
+    offer_info = g.offer_lib.functions.getOfferState(state).call()
 
     return {
-        'isClosed': offer_lib.functions.getCloseFlag(state).call(),
-        'nonce': offer_lib.functions.getSequence(state).call(),
-        'ambassador': offer_lib.functions.getPartyA(state).call(),
-        'expert': offer_lib.functions.getPartyB(state).call(),
-        'msig_address': offer_lib.functions.getMultiSigAddress(state).call(),
-        'ambassador_balance': offer_lib.functions.getBalanceA(state).call(),
-        'expert_balance': offer_lib.functions.getBalanceB(state).call(),
-        'token': offer_lib.functions.getTokenAddress(state).call(),
-        'offer_amount': web3.toInt(offer_info[1]),
-        'mask': int_to_bool_list(web3.toInt(offer_info[6])),
-        'verdicts': int_to_bool_list(web3.toInt(offer_info[7])),
+        'isClosed': g.offer_lib.functions.getCloseFlag(state).call(),
+        'nonce': g.offer_lib.functions.getSequence(state).call(),
+        'ambassador': g.offer_lib.functions.getPartyA(state).call(),
+        'expert': g.offer_lib.functions.getPartyB(state).call(),
+        'msig_address': g.offer_lib.functions.getMultiSigAddress(state).call(),
+        'ambassador_balance': g.offer_lib.functions.getBalanceA(state).call(),
+        'expert_balance': g.offer_lib.functions.getBalanceB(state).call(),
+        'token': g.offer_lib.functions.getTokenAddress(state).call(),
+        'offer_amount': g.web3.toInt(offer_info[1]),
+        'mask': int_to_bool_list(g.web3.toInt(offer_info[6])),
+        'verdicts': int_to_bool_list(g.web3.toInt(offer_info[7])),
     }
 
 def new_init_channel_event_to_dict(new_init_event):
@@ -176,15 +176,13 @@ def new_cancel_agreement_event_to_dict(new_event):
     }
 
 def to_padded_hex(val):
-    web3 = web3_chains['home']
-
     if type(val) == str:
         if val.startswith('0x'):
-            padded_hex = web3.toHex(hexstr=val)[2:]
+            padded_hex = g.web3.toHex(hexstr=val)[2:]
         else:
-            padded_hex = web3.toHex(text=val)[2:]
+            padded_hex = g.web3.toHex(text=val)[2:]
     else:
-        padded_hex = web3.toHex(val)[2:]
+        padded_hex = g.web3.toHex(val)[2:]
 
     l = 64 - len(padded_hex)
 

--- a/src/polyswarmd/websockets.py
+++ b/src/polyswarmd/websockets.py
@@ -10,7 +10,7 @@ from flask import request, g
 from flask_sockets import Sockets
 from geventwebsocket import WebSocketError
 
-from polyswarmd.chains import select_chain
+from polyswarmd.chains import chain
 from polyswarmd.eth import offer_msig_artifact, bind_contract
 from polyswarmd.config import chain_id as chain_ids
 from polyswarmd.utils import channel_to_dict, new_cancel_agreement_event_to_dict, new_settle_started_event, new_settle_challenged_event, new_bounty_event_to_dict, new_assertion_event_to_dict, new_verdict_event_to_dict, state_to_dict, new_init_channel_event_to_dict, new_quorum_event_to_dict, settled_bounty_event_to_dict, revealed_assertion_event_to_dict
@@ -22,7 +22,7 @@ def init_websockets(app):
     message_sockets = dict()
 
     @sockets.route('/events')
-    @select_chain
+    @chain
     def events(ws):
         block_filter = g.web3.eth.filter('latest')
         bounty_filter = g.bounty_registry.eventFilter('NewBounty')
@@ -126,7 +126,7 @@ def init_websockets(app):
                 continue
 
     @sockets.route('/events/<uuid:guid>')
-    @select_chain
+    @chain
     def channel_events(ws, guid):
 
         offer_channel = channel_to_dict(
@@ -176,7 +176,7 @@ def init_websockets(app):
 
     # for receiving messages about offers that might need to be signed
     @sockets.route('/messages/<uuid:guid>')
-    @select_chain(chain_name='home')
+    @chain(chain_name='home')
     def messages(ws, guid):
 
         if guid not in message_sockets:

--- a/src/polyswarmd/websockets.py
+++ b/src/polyswarmd/websockets.py
@@ -6,11 +6,12 @@ import sys
 import time
 
 from jsonschema.exceptions import ValidationError
-from flask import request
+from flask import request, g
 from flask_sockets import Sockets
 from geventwebsocket import WebSocketError
 
-from polyswarmd.eth import web3 as web3_chains, bounty_registry as bounty_chains, offer_registry, bind_contract, offer_msig_artifact
+from polyswarmd.chains import select_chain
+from polyswarmd.eth import offer_msig_artifact, bind_contract
 from polyswarmd.config import chain_id as chain_ids
 from polyswarmd.utils import channel_to_dict, new_cancel_agreement_event_to_dict, new_settle_started_event, new_settle_challenged_event, new_bounty_event_to_dict, new_assertion_event_to_dict, new_verdict_event_to_dict, state_to_dict, new_init_channel_event_to_dict, new_quorum_event_to_dict, settled_bounty_event_to_dict, revealed_assertion_event_to_dict
 
@@ -21,24 +22,18 @@ def init_websockets(app):
     message_sockets = dict()
 
     @sockets.route('/events')
+    @select_chain
     def events(ws):
-        chain = request.args.get('chain', 'home')
-        if chain != 'side' and chain != 'home':
-            logging.error('Chain must be either home or side')
-            ws.close()
-
-        web3 = web3_chains[chain]
-        bounty_registry = bounty_chains[chain]
-
-        block_filter = web3.eth.filter('latest')
-        bounty_filter = bounty_registry.eventFilter('NewBounty')
-        assertion_filter = bounty_registry.eventFilter('NewAssertion')
-        verdict_filter = bounty_registry.eventFilter('NewVerdict')
-        quorum_filiter = bounty_registry.eventFilter('QuorumReached')
-        settled_filter = bounty_registry.eventFilter('BountySettled')
-        reveal_filter = bounty_registry.eventFilter('RevealedAssertion')
-
-        init_filter = offer_registry.eventFilter('InitializedChannel')
+        block_filter = g.web3.eth.filter('latest')
+        bounty_filter = g.bounty_registry.eventFilter('NewBounty')
+        assertion_filter = g.bounty_registry.eventFilter('NewAssertion')
+        verdict_filter = g.bounty_registry.eventFilter('NewVerdict')
+        quorum_filiter = g.bounty_registry.eventFilter('QuorumReached')
+        settled_filter = g.bounty_registry.eventFilter('BountySettled')
+        reveal_filter = g.bounty_registry.eventFilter('RevealedAssertion')
+        init_filter = None
+        if g.offer_registry is not None:
+            init_filter = g.offer_registry.eventFilter('InitializedChannel')
 
         ws.send(
             json.dumps({
@@ -55,7 +50,7 @@ def init_websockets(app):
                         json.dumps({
                             'event': 'block',
                             'data': {
-                                'number': web3.eth.blockNumber,
+                                'number': g.web3.eth.blockNumber,
                             },
                         }))
 
@@ -113,14 +108,15 @@ def init_websockets(app):
                             settled_bounty_event_to_dict(event.args),
                         }))
 
-                for event in init_filter.get_new_entries():
-                    ws.send(
-                        json.dumps({
-                            'event':
-                            'initialized_channel',
-                            'data':
-                            new_init_channel_event_to_dict(event.args),
-                        }))
+                if init_filter is not None:
+                    for event in init_filter.get_new_entries():
+                        ws.send(
+                            json.dumps({
+                                'event':
+                                'initialized_channel',
+                                'data':
+                                new_init_channel_event_to_dict(event.args),
+                            }))
 
                 gevent.sleep(1)
             except WebSocketError:
@@ -130,18 +126,13 @@ def init_websockets(app):
                 continue
 
     @sockets.route('/events/<uuid:guid>')
+    @select_chain
     def channel_events(ws, guid):
-        chain = request.args.get('chain', 'home')
-        if chain != 'side' and chain != 'home':
-            print('Chain must be either home or side', file=sys.stderr)
-            ws.close()
-
-        web3 = web3_chains[chain]
 
         offer_channel = channel_to_dict(
-            offer_registry.functions.guidToChannel(guid.int).call())
+            g.offer_registry.functions.guidToChannel(guid.int).call())
         msig_address = offer_channel['msig_address']
-        offer_msig = bind_contract(web3, msig_address, offer_msig_artifact)
+        offer_msig = bind_contract(g.web3, msig_address, offer_msig_artifact)
 
         closed_agreement_filter = offer_msig.eventFilter('ClosedAgreement')
         settle_started_filter = offer_msig.eventFilter('StartedSettle')
@@ -185,6 +176,7 @@ def init_websockets(app):
 
     # for receiving messages about offers that might need to be signed
     @sockets.route('/messages/<uuid:guid>')
+    @select_chain(chain_name='home')
     def messages(ws, guid):
 
         if guid not in message_sockets:


### PR DESCRIPTION
Adds a decorator (`@chain`) to all routes that need chain info. 
Usually it parses it from the request itself, but in some cases the chain is forced using `@chain(‘home’)`.
It attaches the addrs, web3, and contract bindings to the flask g proxy so the data is only available in the context of a request. 


- [x] needs testing on the sidechain. 