### PR TITLE
Fix broken verdict conversion for array of false values

### DIFF
--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -331,12 +331,15 @@ def post_bounties_guid_assertions_id_reveal(guid, id_):
 @bounties.route('/<uuid:guid>/assertions', methods=['GET'])
 @chain
 def get_bounties_guid_assertions(guid):
+    bounty = bounty_to_dict(
+        g.bounty_registry.functions.bountiesByGuid(guid.int).call())
     num_assertions = g.bounty_registry.functions.getNumberOfAssertions(
         guid.int).call()
     assertions = []
     for i in range(num_assertions):
         assertion = assertion_to_dict(
-            g.bounty_registry.functions.assertionsByGuid(guid.int, i).call())
+            g.bounty_registry.functions.assertionsByGuid(guid.int, i).call(),
+                bounty['num_artifacts'])
         assertions.append(assertion)
 
     return success(assertions)

--- a/src/polyswarmd/utils.py
+++ b/src/polyswarmd/utils.py
@@ -75,12 +75,18 @@ def new_assertion_event_to_dict(new_assertion_event):
 
 
 def revealed_assertion_event_to_dict(revealed_assertion_event):
+    if int(revealed_assertion_event.verdicts) == 0:
+        verdicts = [False]*int(revealed_assertion_event.numArtifacts)
+    else:
+        verdicts = int_to_bool_list(revealed_assertion_event.verdicts)
+
     return {
         'bounty_guid': str(uuid.UUID(int=revealed_assertion_event.bountyGuid)),
         'author': revealed_assertion_event.author,
         'index': revealed_assertion_event.index,
         'nonce': str(revealed_assertion_event.nonce),
-        'verdicts': int_to_bool_list(revealed_assertion_event.verdicts),
+        'verdicts': verdicts,
+        'num_artifacts': revealed_assertion_event.numArtifacts, 
         'metadata': revealed_assertion_event.metadata,
     }
 

--- a/src/polyswarmd/utils.py
+++ b/src/polyswarmd/utils.py
@@ -10,17 +10,22 @@ logger = logging.getLogger(__name__)  # Init logger
 def bool_list_to_int(bs):
     return sum([1 << n if b else 0 for n, b in enumerate(bs)])
 
-
 def int_to_bool_list(i):
     s = format(i, 'b')
     return [x == '1' for x in s[::-1]]
 
+def safe_int_to_bool_list(num, max):
+    if int(num) == 0:
+        return [False]*int(max)
+    else:
+        return verdicts = int_to_bool_list(num)
 
 def uint256_list_to_hex_string(us):
     return hex(sum([x << (256 * n) for n, x in enumerate(us)]))
 
-
 def bounty_to_dict(bounty):
+    bounty_has_voters_and_verdicts = len(bounty) > 10
+
     retval = {
         'guid': str(uuid.UUID(int=bounty[0])),
         'author': bounty[1],
@@ -31,12 +36,12 @@ def bounty_to_dict(bounty):
         'assigned_arbiter': bounty[6],
         'quorum_reached': bounty[7],
         'quorum_reached_block': bounty[8],
-        'quorum_mask': int_to_bool_list(bounty[9]),
+        'quorum_mask': safe_int_to_bool_list(bounty[9], retval['num_artifacts']),
     }
-    if len(bounty) > 10:
+    if bounty_has_voters_and_verdicts:
         retval['bloom'] = uint256_list_to_hex_string(bounty[10])
         retval['voters'] = bounty[11]
-        retval['verdicts'] = int_to_bool_list(bounty[12])
+        retval['verdicts'] = safe_int_to_bool_list(bounty[12], retval['num_artifacts'])
         retval['bloom_votes'] = bounty[13]
     return retval
 
@@ -51,14 +56,14 @@ def new_bounty_event_to_dict(new_bounty_event):
     }
 
 
-def assertion_to_dict(assertion):
+def assertion_to_dict(assertion, num_artifacts):
     return {
         'author': assertion[0],
         'bid': str(assertion[1]),
-        'mask': int_to_bool_list(assertion[2]),
+        'mask': safe_int_to_bool_list(assertion[2], num_artifacts),
         'commitment': str(assertion[3]),
         'nonce': str(assertion[4]),
-        'verdicts': int_to_bool_list(assertion[5]),
+        'verdicts': safe_int_to_bool_list(assertion[5], num_artifacts),
         'metadata': assertion[6],
     }
 
@@ -69,32 +74,25 @@ def new_assertion_event_to_dict(new_assertion_event):
         'author': new_assertion_event.author,
         'index': new_assertion_event.index,
         'bid': str(new_assertion_event.bid),
-        'mask': int_to_bool_list(new_assertion_event.mask),
+        'mask': safe_int_to_bool_list(new_assertion_event.mask, new_assertion_event.numArtifacts),
         'commitment': str(new_assertion_event.commitment),
     }
 
 
 def revealed_assertion_event_to_dict(revealed_assertion_event):
-    if int(revealed_assertion_event.verdicts) == 0:
-        verdicts = [False]*int(revealed_assertion_event.numArtifacts)
-    else:
-        verdicts = int_to_bool_list(revealed_assertion_event.verdicts)
-
     return {
         'bounty_guid': str(uuid.UUID(int=revealed_assertion_event.bountyGuid)),
         'author': revealed_assertion_event.author,
         'index': revealed_assertion_event.index,
         'nonce': str(revealed_assertion_event.nonce),
-        'verdicts': verdicts,
-        'num_artifacts': revealed_assertion_event.numArtifacts, 
+        'verdicts': safe_int_to_bool_list(revealed_assertion_event.verdicts, revealed_assertion_event.numArtifacts),
         'metadata': revealed_assertion_event.metadata,
     }
-
 
 def new_verdict_event_to_dict(new_verdict_event):
     return {
         'bounty_guid': str(uuid.UUID(int=new_verdict_event.bountyGuid)),
-        'verdicts': int_to_bool_list(new_verdict_event.verdicts),
+        'verdicts': safe_int_to_bool_list(new_verdict_event.verdicts, new_verdict_event.numArtifacts),
         'voter': new_verdict_event.voter,
     }
 


### PR DESCRIPTION
This fixes to the problem described here https://github.com/orgs/polyswarm/projects/3. It makes sure that ints are converted to the correct length of false values using [safe_int_to_bool_list](https://github.com/polyswarm/polyswarmd/compare/fix/broken-verdict?expand=1#diff-b1887ed9b3488f80073b7b3fe9b14315R18).