### PR TITLE
add check for empty bounty

### DIFF
--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -332,13 +332,13 @@ def post_bounties_guid_assertions_id_reveal(guid, id_):
 @bounties.route('/<uuid:guid>/assertions', methods=['GET'])
 @chain
 def get_bounties_guid_assertions(guid):
-    try:
-        bounty = bounty_to_dict(
-            g.bounty_registry.functions.bountiesByGuid(guid.int).call())
-        num_assertions = g.bounty_registry.functions.getNumberOfAssertions(
-            guid.int).call()
-    except:
+    bounty = bounty_to_dict(
+        g.bounty_registry.functions.bountiesByGuid(guid.int).call())
+    if bounty['author'] == zero_address:
         return failure('Bounty not found', 404)
+
+    num_assertions = g.bounty_registry.functions.getNumberOfAssertions(
+        guid.int).call()
 
     assertions = []
     for i in range(num_assertions):
@@ -357,9 +357,8 @@ def get_bounties_guid_assertions(guid):
 @bounties.route('/<uuid:guid>/assertions/<int:id_>', methods=['GET'])
 @chain
 def get_bounties_guid_assertions_id(guid, id_):
-    try:
-        bounty = bounty_to_dict(g.bounty_registry.functions.bountiesByGuid(guid.int).call())
-    except:
+    bounty = bounty_to_dict(g.bounty_registry.functions.bountiesByGuid(guid.int).call())
+    if bounty['author'] == zero_address:
         return failure('Bounty not found', 404)
 
     try:


### PR DESCRIPTION
Should help fix the assertion [error](https://app.datadoghq.com/logs?cols=%5B%22core_host%22%2C%22core_service%22%5D&event&from_ts=1540840223380&index=main&live=false&query=container_name%3Agamma_polyswarmd.1.%2A+status%3A%28error+OR+info+OR+warn%29&stream_sort=desc&to_ts=1540840226829) we see on restarts.

strangely the line below returns a huge number when using geth if the bounty doesn't exist when it should be reverted. This caused polyswarmd to loop forever
https://github.com/polyswarm/polyswarmd/blob/bb3dfa7897efac99e4f2f2b015693c907b01ee8d/src/polyswarmd/bounties.py#L342
