### PR TITLE
Bump to pre-release version of PyYAML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jsonschema==2.6.0
 Flask==1.0.2
 Flask-Sockets==0.2.1
 psycopg2-binary==2.7.6.1
-PyYaml==3.13
+PyYaml==4.2b4
 pytest== 4.0.0
 python-json-logger==0.1.9
 requests==2.20.1


### PR DESCRIPTION
Apparently stable is still vulnerable, bumping to pre-release.