### PR TITLE
Allow clients to recover from known transaction issues

### DIFF
--- a/src/polyswarmd/__main__.py
+++ b/src/polyswarmd/__main__.py
@@ -9,7 +9,7 @@ from polyswarmd import app
 
 
 @click.command()
-@click.option('--log', default='INFO', help="Logging level")
+@click.option('--log', default='INFO', help='Logging level')
 @click.option('--host', default='', help='Host to listen on')
 @click.option('--port', default=31337, help='Port to listen on')
 def main(log, host, port):

--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -128,8 +128,8 @@ def post_transactions():
     if withdrawal_only and len(body['transactions']) != 1:
         return failure('Posting multiple transactions requires an API key', 403)
 
-    errors = []
-    txhashes = []
+    errors = False
+    results = []
     for raw_tx in body['transactions']:
         try:
             tx = rlp.decode(bytes.fromhex(raw_tx), Transaction)
@@ -141,31 +141,48 @@ def post_transactions():
             continue
 
         if withdrawal_only and not is_withdrawal(tx):
-            errors.append(
-                'Invalid transaction for tx {0}: only withdrawals allowed without an API key'.format(tx.hash.hex()))
+            errors = True
+            results.append({
+                'is_error': True,
+                'message': 'Invalid transaction for tx {0}: only withdrawals allowed without an API key'.format(tx.hash.hex())
+            })
             continue
 
         sender = g.chain.w3.toChecksumAddress(tx.sender.hex())
         if sender != account:
-            errors.append(
-                'Invalid transaction sender for tx {0}: expected {1} got {2}'.format(tx.hash.hex(), account, sender))
+            errors = True
+            results.append({
+                'is_error': True,
+                'message': 'Invalid transaction sender for tx {0}: expected {1} got {2}'.format(tx.hash.hex(), account, sender)
+            })
             continue
 
         # Redundant check against zero address, but explicitly guard against contract deploys via this route
         to = g.chain.w3.toChecksumAddress(tx.to.hex())
         if to == ZERO_ADDRESS or to not in contract_addresses:
-            errors.append(
-                'Invalid transaction recipient for tx {0}: {1}'.format(tx.hash.hex(), to))
+            errors = True
+            results.append({
+                'is_error': True,
+                'message':  'Invalid transaction recipient for tx {0}: {1}'.format(tx.hash.hex(), to)
+            })
             continue
 
         logger.info('Sending tx from %s to %s with nonce %s', sender, to, tx.nonce)
 
         try:
-            txhashes.append(g.chain.w3.eth.sendRawTransaction(HexBytes(raw_tx)))
+            results.append({
+                'is_error': False,
+                'message': g.chain.w3.eth.sendRawTransaction(HexBytes(raw_tx)).hex()})
         except ValueError as e:
-            errors.append('Invalid transaction error for tx {0}: {1}'.format(tx.hash.hex(), e))
+            errors = True
+            results.append({
+                'is_error': True,
+                'message': 'Invalid transaction error for tx {0}: {1}'.format(tx.hash.hex(), e)
+            })
+    if errors:
+        return failure(results, 400)
 
-    return success([txhash.hex() for txhash in txhashes])
+    return success(results)
 
 def build_transaction(call, nonce):
     options = {


### PR DESCRIPTION
Separate /transactions into GET and POST. 

The POST route returns a list of tx hashes and errors. 
The GET route returns a dict of list of events, or errors. 