### PR TITLE
Fix/get tx timeouts

### DIFF
--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -235,6 +235,12 @@ def post_bounties_guid_assertions(guid):
                     'type': 'boolean',
                 },
             },
+            'commitment': {
+                'type': 'string',
+                'minLength': 1,
+                'maxLength': 100,
+                'pattern': r'^\d+$',
+            },
         },
         'required': ['bid', 'mask'],
     }

--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -77,8 +77,6 @@ def get_nonce():
 @misc.route('/transactions', methods=['GET'])
 @chain
 def get_transactions():
-    account = g.chain.w3.toChecksumAddress(g.eth_address)
-
     schema = {
         'type': 'object',
         'properties': {
@@ -271,8 +269,7 @@ def events_from_transaction(txhash):
             pass
 
     # TODO: Check for out of gas, other
-    # TODO: Report contract errors
-    timeout = gevent.Timeout(60)
+    timeout = gevent.Timeout(20)
     timeout.start()
 
     try:
@@ -288,13 +285,13 @@ def events_from_transaction(txhash):
         logging.exception('Transaction %s: timeout waiting for receipt', bytes(txhash).hex())
         return {
             'errors':
-                ['Invalid transaction error for {0}: timeout during wait for receipt'.format(bytes(txhash).hex())]
+                ['transaction {0}: timeout during wait for receipt'.format(bytes(txhash).hex())]
         }
     except Exception:
         logger.exception('Transaction %s: error while fetching transaction receipt', bytes(txhash).hex())
         return {
             'errors':
-                ['transaction {0}: unhandled error while fetching transaction receipt'.format(bytes(txhash).hex())]
+                ['transaction {0}: unexpected error while fetching transaction receipt'.format(bytes(txhash).hex())]
         }
     finally:
         timeout.cancel()

--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -269,7 +269,7 @@ def events_from_transaction(txhash):
             pass
 
     # TODO: Check for out of gas, other
-    timeout = gevent.Timeout(20)
+    timeout = gevent.Timeout(10)
     timeout.start()
 
     try:

--- a/src/polyswarmd/monkey.py
+++ b/src/polyswarmd/monkey.py
@@ -16,7 +16,7 @@ def patch_gevent():
 
 def patch_web3():
     def make_post_request(endpoint_uri, data, *args, **kwargs):
-        kwargs.setdefault('timeout', 1)
+        kwargs.setdefault('timeout', 2)
         future = session.post(endpoint_uri, data=data, *args, **kwargs)
         response = future.result()
         response.raise_for_status()

--- a/src/polyswarmd/monkey.py
+++ b/src/polyswarmd/monkey.py
@@ -16,7 +16,7 @@ def patch_gevent():
 
 def patch_web3():
     def make_post_request(endpoint_uri, data, *args, **kwargs):
-        kwargs.setdefault('timeout', 2)
+        kwargs.setdefault('timeout', 1)
         future = session.post(endpoint_uri, data=data, *args, **kwargs)
         response = future.result()
         response.raise_for_status()


### PR DESCRIPTION
Don't try to resync on receipt timeout, decrease the receipt timeout from 60 (GET route means we can retry)

Currently on staging