### PR TITLE
Loosen version check, ERC20Relay not deployed automatically so mark o…

### DIFF
--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 CONFIG_LOCATIONS = ['/etc/polyswarmd', '~/.config/polyswarmd']
 
 # Allow interfacing with contract versions in this range
-SUPPORTED_CONTRACT_VERSIONS = ((1, 2, 0), (1, 3, 0))
+SUPPORTED_CONTRACT_VERSIONS = ((1, 1, 0), (1, 3, 0))
 
 # Skip version check for these contracts
 SKIP_VERSION_CHECK = {'NectarToken'}


### PR DESCRIPTION
Contract versions in lockstep however ERC20Relay not deployed automatically in default configuration, loosen version spec for this case.

This is currently deployed on stage.