### PR TITLE
Add artifact type to bounty

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ websocket-client==0.48.0
 Werkzeug==0.14.1
 rlp==1.1.0
 git+https://github.com/polyswarm/flask-profiler.git@profile-stats#egg=flask_profiler
-polyswarm-artifact==0.1.0
+polyswarm-artifact==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ websocket-client==0.48.0
 Werkzeug==0.14.1
 rlp==1.1.0
 git+https://github.com/polyswarm/flask-profiler.git@profile-stats#egg=flask_profiler
+polyswarm-artifact

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ websocket-client==0.48.0
 Werkzeug==0.14.1
 rlp==1.1.0
 git+https://github.com/polyswarm/flask-profiler.git@profile-stats#egg=flask_profiler
-polyswarm-artifact
+polyswarm-artifact==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 def parse_requirements():
     with open('requirements.txt', 'r') as f:
-        return [r for r in f.read().splitlines() if not r.startswith('git')]
+        return [r for r in f.read().splitlines() if not r.startswith('git') and not r.startswith('.')]
 
 setup(name='polyswarmd',
       version='0.3',

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -79,7 +79,7 @@ def post_bounties():
                 'minimum': 1,
             },
         },
-        'required': ['required', 'amount', 'uri', 'duration'],
+        'required': ['artifact_type', 'amount', 'uri', 'duration'],
     }
 
     body = request.get_json()

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -59,6 +59,10 @@ def post_bounties():
     schema = {
         'type': 'object',
         'properties': {
+            'artifact_type': {
+                'type': 'string',
+                'enum': ['file', 'url']
+            },
             'amount': {
                 'type': 'string',
                 'minLength': 1,
@@ -75,7 +79,7 @@ def post_bounties():
                 'minimum': 1,
             },
         },
-        'required': ['amount', 'uri', 'duration'],
+        'required': ['required', 'amount', 'uri', 'duration'],
     }
 
     body = request.get_json()
@@ -85,33 +89,35 @@ def post_bounties():
         return failure('Invalid JSON: ' + e.message, 400)
 
     guid = uuid.uuid4()
+    artifact_type = body['artifact_type']
     amount = int(body['amount'])
-    artifactURI = body['uri']
-    durationBlocks = body['duration']
+    artifact_uri = body['uri']
+    duration_blocks = body['duration']
 
     if amount < eth.bounty_amount_min(g.chain.bounty_registry.contract):
         return failure('Invalid bounty amount', 400)
 
-    if not is_valid_ipfshash(artifactURI):
+    if not is_valid_ipfshash(artifact_uri):
         return failure('Invalid artifact URI (should be IPFS hash)', 400)
 
-    arts = list_artifacts(artifactURI)
+    arts = list_artifacts(artifact_uri)
     if not arts:
         return failure('Invalid artifact URI (could not retrieve artifacts)',
                        400)
 
-    numArtifacts = len(arts)
+    num_artifacts = len(arts)
     bloom = calculate_bloom(arts)
 
-    approveAmount = amount + eth.bounty_fee(g.chain.bounty_registry.contract)
+    approve_amount = amount + eth.bounty_fee(g.chain.bounty_registry.contract)
 
     transactions = [
         build_transaction(
-            g.chain.nectar_token.contract.functions.approve(g.chain.bounty_registry.contract.address, approveAmount),
+            g.chain.nectar_token.contract.functions.approve(g.chain.bounty_registry.contract.address, approve_amount),
             base_nonce),
         build_transaction(
-            g.chain.bounty_registry.contract.functions.postBounty(guid.int, amount, artifactURI, numArtifacts,
-                                                                  durationBlocks, bloom), base_nonce + 1),
+            g.chain.bounty_registry.contract.functions.postBounty(guid.int, artifact_type, amount, artifact_uri,
+                                                                  num_artifacts, duration_blocks, bloom),
+            base_nonce + 1),
     ]
 
     return success({'transactions': transactions})

--- a/src/polyswarmd/utils.py
+++ b/src/polyswarmd/utils.py
@@ -6,6 +6,8 @@ import uuid
 from typing import AnyStr, Union
 
 from flask import g
+from polyswarmartifact import ArtifactType
+
 from polyswarmd.eth import ZERO_ADDRESS
 
 logger = logging.getLogger(__name__)
@@ -34,7 +36,7 @@ def uint256_list_to_hex_string(us):
 def bounty_to_dict(bounty):
     return {
         'guid': str(uuid.UUID(int=bounty[0])),
-        'artifact_type': bounty[1],
+        'artifact_type': ArtifactType.to_string(ArtifactType(bounty[1])),
         'author': bounty[2],
         'amount': str(bounty[3]),
         'uri': bounty[4],
@@ -70,7 +72,7 @@ def window_update_event_to_dict(window_update_event):
 def new_bounty_event_to_dict(new_bounty_event):
     return {
         'guid': str(uuid.UUID(int=new_bounty_event.guid)),
-        'artifact_type': str(new_bounty_event.artifactType),
+        'artifact_type': ArtifactType.to_string(ArtifactType(new_bounty_event.artifactType)),
         'author': new_bounty_event.author,
         'amount': str(new_bounty_event.amount),
         'uri': new_bounty_event.artifactURI,

--- a/src/polyswarmd/utils.py
+++ b/src/polyswarmd/utils.py
@@ -34,15 +34,16 @@ def uint256_list_to_hex_string(us):
 def bounty_to_dict(bounty):
     return {
         'guid': str(uuid.UUID(int=bounty[0])),
-        'author': bounty[1],
-        'amount': str(bounty[2]),
-        'uri': bounty[3],
-        'num_artifacts': bounty[4],
-        'expiration': bounty[5],
-        'assigned_arbiter': bounty[6],
-        'quorum_reached': bounty[7],
-        'quorum_reached_block': bounty[8],
-        'quorum_mask': safe_int_to_bool_list(bounty[9], bounty[4]),
+        'artifact_type': bounty[1],
+        'author': bounty[2],
+        'amount': str(bounty[3]),
+        'uri': bounty[4],
+        'num_artifacts': bounty[5],
+        'expiration': bounty[6],
+        'assigned_arbiter': bounty[7],
+        'quorum_reached': bounty[8],
+        'quorum_reached_block': bounty[9],
+        'quorum_mask': safe_int_to_bool_list(bounty[10], bounty[5]),
     }
 
 
@@ -69,6 +70,7 @@ def window_update_event_to_dict(window_update_event):
 def new_bounty_event_to_dict(new_bounty_event):
     return {
         'guid': str(uuid.UUID(int=new_bounty_event.guid)),
+        'artifact_type': str(new_bounty_event.artifactType),
         'author': new_bounty_event.author,
         'amount': str(new_bounty_event.amount),
         'uri': new_bounty_event.artifactURI,


### PR DESCRIPTION
Requires artifact_type when posing bounties. 

I thought about making this not required to avoid a breaking polyswarm-client change, but psc does checks against the decoded message, and it would reject any transactions with the artifact-type specified.

Also, extracts the artifact type from the bounty events, or when reading from the chain. 