### PR TITLE
Print a ready message once server is ready

### DIFF
--- a/src/polyswarmd/__main__.py
+++ b/src/polyswarmd/__main__.py
@@ -7,6 +7,8 @@ from geventwebsocket.handler import WebSocketHandler
 
 from polyswarmd.logger import init_logging
 
+logger = logging.getLogger(__name__)
+
 
 @click.command()
 @click.option('--log-format', envvar='LOG_FORMAT', default='text', help='Logging format')
@@ -23,6 +25,8 @@ def main(log_format, log_level, host, port):
 
     from polyswarmd import app
     server = pywsgi.WSGIServer((host, port), app, handler_class=WebSocketHandler)
+
+    logger.critical("polyswarmd is ready!")
     server.serve_forever()
 
 

--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -357,8 +357,6 @@ class Config(object):
         t = threading.Thread(target=watch_for_config_deletion, args=(consul_client, base_key))
         t.start()
 
-        logger.critical("polyswarmd is ready!")
-
         return ret
 
     @classmethod

--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -357,6 +357,8 @@ class Config(object):
         t = threading.Thread(target=watch_for_config_deletion, args=(consul_client, base_key))
         t.start()
 
+        logger.critical("polyswarmd is ready!")
+
         return ret
 
     @classmethod

--- a/src/polyswarmd/wsgi.py
+++ b/src/polyswarmd/wsgi.py
@@ -4,6 +4,8 @@ import os
 
 from polyswarmd.logger import init_logging
 
+logger = logging.getLogger(__name__)
+
 
 def app(*args, **kwargs):
     # Can't directly pass command line arguments via gunicorn, but can pass arguments to callable

--- a/src/polyswarmd/wsgi.py
+++ b/src/polyswarmd/wsgi.py
@@ -19,4 +19,5 @@ def app(*args, **kwargs):
     init_logging(log_format, log_level)
 
     from polyswarmd import app as application
+    logger.critical("polyswarmd is ready!")
     return application

--- a/src/polyswarmd/wsgi.py
+++ b/src/polyswarmd/wsgi.py
@@ -21,5 +21,6 @@ def app(*args, **kwargs):
     init_logging(log_format, log_level)
 
     from polyswarmd import app as application
+
     logger.critical("polyswarmd is ready!")
     return application


### PR DESCRIPTION
I think this might be an appropriate place to call our that polyswarmd is ready for service. It's immediately following config loads from consul.