### PR TITLE
Reduce WARNING to DEBUG

### DIFF
--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -222,7 +222,7 @@ def build_transaction(call, nonce):
         gas = int(call.estimateGas({'from': g.eth_address, **options}) * GAS_MULTIPLIER)
         options['gas'] = min(MAX_GAS_LIMIT, gas)
     except ValueError as e:
-        logger.warning('Error estimating gas, using default: %s', e)
+        logger.debug('Error estimating gas, using default: %s', e)
 
     logger.info('options: %s', options)
 


### PR DESCRIPTION
Users of polyswarmd via integration testing should not be concerned with an inability to estimate gas. This should be under their threshold.