### PR TITLE
Add route to upload metadata to IPFS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ gevent==1.2.2
 gevent-websocket==0.10.1
 jsonschema==2.6.0
 Flask==1.0.2
+Flask-Caching==1.7.2
 Flask-Sockets==0.2.1
+polyswarm-artifact==1.1.0
 psycopg2-binary==2.7.6.1
 PyYaml==4.2b4
 pytest== 4.0.0
@@ -14,9 +16,8 @@ python-json-logger==0.1.9
 requests==2.20.1
 requests-futures==0.9.9
 requests-mock==1.5.0
+rlp==1.1.0
 web3==4.8.1
 websocket-client==0.48.0
 Werkzeug==0.14.1
-rlp==1.1.0
 git+https://github.com/polyswarm/flask-profiler.git@profile-stats#egg=flask_profiler
-polyswarm-artifact==1.0.0

--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 
 from flask import Flask, g, request
+from flask_caching import Cache
 from requests_futures.sessions import FuturesSession
 
 from polyswarmd.config import Config, is_service_reachable
@@ -19,6 +20,8 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 app.config['POLYSWARMD'] = Config.auto()
 app.config['REQUESTS_SESSION'] = FuturesSession(adapter_kwargs={'max_retries': 5})
+
+cache = Cache(config={"CACHE_TYPE": "simple", "CACHE_DEFAULT_TIMEOUT": 30})
 
 install_error_handlers(app)
 
@@ -44,6 +47,7 @@ app.register_blueprint(staking, url_prefix='/staking')
 
 init_websockets(app)
 setup_profiler(app)
+cache.init_app(app)
 
 AUTH_WHITELIST = {'/status', '/relay/withdrawal', '/transactions'}
 

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -54,7 +54,7 @@ def calculate_commitment(account, verdicts):
     return int_from_bytes(nonce), int_from_bytes(commitment)
 
 
-def fetch_ipfs_metadata(session, config, ipfs_uri):
+def substitute_ipfs_metadata(session, config, ipfs_uri):
     """Download metadata from IPFS and validate it against the schema.
 
     :param session: Requests session
@@ -413,7 +413,7 @@ def get_bounties_guid_assertions(guid):
             assertion = assertion_to_dict(
                 g.chain.bounty_registry.contract.functions.assertionsByGuid(guid.int, i).call(),
                 bounty['num_artifacts'])
-            assertion['metadata'] = fetch_ipfs_metadata(session, config, assertion.get('metadata', ''))
+            assertion['metadata'] = substitute_ipfs_metadata(session, config, assertion.get('metadata', ''))
             assertions.append(assertion)
         except Exception:
             logger.exception('Could not retrieve assertion')
@@ -436,7 +436,7 @@ def get_bounties_guid_assertions_id(guid, id_):
     try:
         assertion = assertion_to_dict(g.chain.bounty_registry.contract.functions.assertionsByGuid(guid.int, id_).call(),
                                       bounty['num_artifacts'])
-        assertion['metadata'] = fetch_ipfs_metadata(session, config, assertion.get('metadata', ''))
+        assertion['metadata'] = substitute_ipfs_metadata(session, config, assertion.get('metadata', ''))
 
         return success(assertion)
     except:

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -64,7 +64,8 @@ def download_and_verify_metadata(session, config, ipfs_uri):
             else:
                 logger.critical(f'Got {r.status_code} from ipfs with uri {ipfs_uri}')
         except json.JSONDecodeError:
-            logger.exception('Metadata retrieved from IPFS does not match schema')
+            # Expected when people provide incorrect metadata. Not stack worthy
+            logger.warning('Metadata retrieved from IPFS does not match schema')
         except Exception:
             logger.exception('Received error retrieving files from IPFS, got response: %s',
                              r.content if r is not None else 'None')
@@ -242,7 +243,9 @@ def post_assertion_metadata():
         if not AssertionMetadata.validate(json.loads(body)):
             return failure('Invalid AssertionMetadata', 400)
     except json.JSONDecodeError:
-        logger.exception(f'Invalid JSON')
+        # Expected when people provide incorrect metadata. Not stack worthy
+        logger.warning(f'Invalid JSON')
+        return failure('Invalid Assertion metadata', 400)
 
     config = app.config['POLYSWARMD']
     session = app.config['REQUESTS_SESSION']

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -4,14 +4,13 @@ import os
 import jsonschema
 import uuid
 
-import requests
 from ethereum.utils import sha3
 from flask import Blueprint, g, request
 from jsonschema.exceptions import ValidationError
 from polyswarmartifact import ArtifactType
 from polyswarmartifact.schema.assertion import Assertion as AssertionMetadata
 
-from polyswarmd import eth, app, cache
+from polyswarmd import eth, cache
 from polyswarmd.artifacts import is_valid_ipfshash, list_artifacts, post_to_ipfs, get_from_ipfs
 from polyswarmd.chains import chain
 from polyswarmd.bloom import BloomFilter, FILTER_BITS
@@ -54,11 +53,9 @@ def calculate_commitment(account, verdicts):
     return int_from_bytes(nonce), int_from_bytes(commitment)
 
 
-def substitute_ipfs_metadata(session, config, ipfs_uri):
+def substitute_ipfs_metadata(ipfs_uri):
     """Download metadata from IPFS and validate it against the schema.
 
-    :param session: Requests session
-    :param config: Flask config object
     :param ipfs_uri: Porential IPFS uri string
     :return: Metadata from IPFS, or original metadata
     """
@@ -66,15 +63,14 @@ def substitute_ipfs_metadata(session, config, ipfs_uri):
         return ipfs_uri
 
     status_code, content = get_from_ipfs(ipfs_uri)
-    if status_code // 100 != 2:
-        return ipfs_uri
-
     try:
-        content = json.loads(content.decode('utf-8'))
-        return content if AssertionMetadata.validate(content) else ipfs_uri
+        if status_code // 100 == 2 and AssertionMetadata.validate(json.loads(content.decode('utf-8'))):
+            return json.loads(content.decode('utf-8'))
     except json.JSONDecodeError:
         # Expected when people provide incorrect metadata. Not stack worthy
         logger.warning('Metadata retrieved from IPFS does not match schema')
+    except Exception:
+        logger.exception('Error getting metadata from IPFS')
 
     return ipfs_uri
 
@@ -393,9 +389,6 @@ def post_bounties_guid_assertions_id_reveal(guid, id_):
 @cache.memoize(30)
 @chain
 def get_bounties_guid_assertions(guid):
-    config = app.config['POLYSWARMD']
-    session = app.config['REQUESTS_SESSION']
-
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
     if bounty['author'] == ZERO_ADDRESS:
         return failure('Bounty not found', 404)
@@ -408,7 +401,7 @@ def get_bounties_guid_assertions(guid):
             assertion = assertion_to_dict(
                 g.chain.bounty_registry.contract.functions.assertionsByGuid(guid.int, i).call(),
                 bounty['num_artifacts'])
-            assertion['metadata'] = substitute_ipfs_metadata(session, config, assertion.get('metadata', ''))
+            assertion['metadata'] = substitute_ipfs_metadata(assertion.get('metadata', ''))
             assertions.append(assertion)
         except Exception:
             logger.exception('Could not retrieve assertion')
@@ -421,9 +414,6 @@ def get_bounties_guid_assertions(guid):
 @cache.memoize(30)
 @chain
 def get_bounties_guid_assertions_id(guid, id_):
-    config = app.config['POLYSWARMD']
-    session = app.config['REQUESTS_SESSION']
-
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
     if bounty['author'] == ZERO_ADDRESS:
         return failure('Bounty not found', 404)
@@ -431,7 +421,7 @@ def get_bounties_guid_assertions_id(guid, id_):
     try:
         assertion = assertion_to_dict(g.chain.bounty_registry.contract.functions.assertionsByGuid(guid.int, id_).call(),
                                       bounty['num_artifacts'])
-        assertion['metadata'] = substitute_ipfs_metadata(session, config, assertion.get('metadata', ''))
+        assertion['metadata'] = substitute_ipfs_metadata(assertion.get('metadata', ''))
 
         return success(assertion)
     except:

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -259,11 +259,9 @@ def post_assertion_metadata():
                               files=[('metadata', body)],
                               params={'wrap-with-directory': False})
         r = future.result()
-        if r.status_code // 100 != 2:
-            return failure('Failed to upload to IPFS', r.status_code)
-
-        ipfshash = json.loads(r.text.splitlines()[-1])['Hash']
-        return success(ipfshash)
+        return success(json.loads(r.text.splitlines()[-1])['Hash']) \
+            if r.status_code // 100 == 2 \
+            else failure('Failed to upload to IPFS', r.status_code)
 
     except json.JSONDecodeError:
         # Expected when people provide incorrect metadata. Not stack worthy

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -259,10 +259,8 @@ def post_assertion_metadata():
 
     try:
         status_code, ipfshash = post_to_ipfs([('metadata', body)], wrap_dir=False)
-        if status_code // 100 == 2:
-            return success(ipfshash)
-        else:
-            return failure('Could not add metadata to IPFS', status_code)
+        return success(ipfshash) if status_code // 100 == 2 else failure('Could not add metadata to IPFS', status_code)
+
     except Exception:
         logger.exception('Received error posting to IPFS got response')
         return failure('Could not add metadata to ipfs', 400)

--- a/src/polyswarmd/websockets.py
+++ b/src/polyswarmd/websockets.py
@@ -81,27 +81,26 @@ def init_websockets(app):
                         }))
 
                 for event in assertion_filter.get_new_entries():
-                    assertion = {
-                        'event': 'assertion',
-                        'data': new_assertion_event_to_dict(event.args),
-                        'block_number': event.blockNumber,
-                        'txhash': event.transactionHash.hex(),
-                    }
-                    metadata = download_and_verify_metadata(session, config, assertion.get('metadata', ''))
-                    if metadata is not None:
-                        assertion['metadata_uri'] = assertion.get('metadata', '')
-                        assertion['metadata'] = metadata
-
-                    ws.send(json.dumps(assertion))
-
-                for event in reveal_filter.get_new_entries():
                     ws.send(
                         json.dumps({
-                            'event': 'reveal',
-                            'data': revealed_assertion_event_to_dict(event.args),
+                            'event': 'assertion',
+                            'data': new_assertion_event_to_dict(event.args),
                             'block_number': event.blockNumber,
                             'txhash': event.transactionHash.hex(),
                         }))
+
+                for event in reveal_filter.get_new_entries():
+                    reveal = {
+                        'event': 'reveal',
+                        'data': revealed_assertion_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex(),
+                    }
+                    metadata = download_and_verify_metadata(session, config, reveal['data'].get('metadata', ''))
+                    if metadata is not None:
+                        reveal['data']['metadata'] = json.dumps(metadata)
+
+                    ws.send(json.dumps(reveal))
 
                 for event in vote_filter.get_new_entries():
                     ws.send(

--- a/src/polyswarmd/websockets.py
+++ b/src/polyswarmd/websockets.py
@@ -20,9 +20,6 @@ def init_websockets(app):
     start_time = time.time()
     message_sockets = dict()
 
-    config = app.config['POLYSWARMD']
-    session = app.config['REQUESTS_SESSION']
-
     @sockets.route('/events')
     @chain(account_required=False)
     def events(ws):
@@ -96,7 +93,7 @@ def init_websockets(app):
                         'block_number': event.blockNumber,
                         'txhash': event.transactionHash.hex(),
                     }
-                    reveal['data']['metadata'] = substitute_ipfs_metadata(session, config, reveal['data'].get('metadata', ''))
+                    reveal['data']['metadata'] = substitute_ipfs_metadata(reveal['data'].get('metadata', ''))
 
                     ws.send(json.dumps(reveal))
 

--- a/src/polyswarmd/websockets.py
+++ b/src/polyswarmd/websockets.py
@@ -8,7 +8,7 @@ from geventwebsocket import WebSocketError
 from jsonschema.exceptions import ValidationError
 from requests.exceptions import ConnectionError
 
-from polyswarmd.bounties import download_and_verify_metadata
+from polyswarmd.bounties import fetch_ipfs_metadata
 from polyswarmd.chains import chain
 from polyswarmd.utils import *
 
@@ -96,9 +96,7 @@ def init_websockets(app):
                         'block_number': event.blockNumber,
                         'txhash': event.transactionHash.hex(),
                     }
-                    metadata = download_and_verify_metadata(session, config, reveal['data'].get('metadata', ''))
-                    if metadata is not None:
-                        reveal['data']['metadata'] = json.dumps(metadata)
+                    reveal['data']['metadata'] = fetch_ipfs_metadata(session, config, reveal['data'].get('metadata', ''))
 
                     ws.send(json.dumps(reveal))
 

--- a/src/polyswarmd/websockets.py
+++ b/src/polyswarmd/websockets.py
@@ -8,7 +8,7 @@ from geventwebsocket import WebSocketError
 from jsonschema.exceptions import ValidationError
 from requests.exceptions import ConnectionError
 
-from polyswarmd.bounties import fetch_ipfs_metadata
+from polyswarmd.bounties import substitute_ipfs_metadata
 from polyswarmd.chains import chain
 from polyswarmd.utils import *
 
@@ -96,7 +96,7 @@ def init_websockets(app):
                         'block_number': event.blockNumber,
                         'txhash': event.transactionHash.hex(),
                     }
-                    reveal['data']['metadata'] = fetch_ipfs_metadata(session, config, reveal['data'].get('metadata', ''))
+                    reveal['data']['metadata'] = substitute_ipfs_metadata(session, config, reveal['data'].get('metadata', ''))
 
                     ws.send(json.dumps(reveal))
 


### PR DESCRIPTION
Also, pulls the file from IPFS and reads metadata on websockets, and on get assertion routes. 

Rejects non conforming metadata to IPFS (but still allows to contract)