### PR TITLE
Add LRU cache to function that takes an ipfs uri and returns the metadata

### DIFF
--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import logging
 import os
@@ -53,6 +54,7 @@ def calculate_commitment(account, verdicts):
     return int_from_bytes(nonce), int_from_bytes(commitment)
 
 
+@functools.lru_cache(maxsize=128)
 def substitute_ipfs_metadata(ipfs_uri):
     """Download metadata from IPFS and validate it against the schema.
 


### PR DESCRIPTION
Retrieving the metadata from ipfs blocks the geth filter to websocket loop.
This adds a cache on the function that retrieves the metadata so doesn't block the loop on IO after the first time. 