### PR TITLE
Lower timeout and retries, update status route

### DIFF
--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -23,7 +23,7 @@ app = Flask(__name__)
 app.config['POLYSWARMD'] = Config.auto()
 
 session = FuturesSession(executor=ThreadPoolExecutor(16),
-                                                adapter_kwargs={'max_retries': 3})
+                         adapter_kwargs={'max_retries': 3})
 
 session.request = functools.partial(session.request, timeout=3)
 

--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -22,8 +22,12 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 app.config['POLYSWARMD'] = Config.auto()
 
-app.config['REQUESTS_SESSION'] = FuturesSession(executor=ThreadPoolExecutor(16),
-                                                adapter_kwargs={'max_retries': 3, 'timeout': 5})
+session = FuturesSession(executor=ThreadPoolExecutor(16),
+                                                adapter_kwargs={'max_retries': 3})
+
+session.request = functools.partial(session.request, timeout=3)
+
+app.config['REQUESTS_SESSION'] = session
 
 cache = Cache(config={"CACHE_TYPE": "simple", "CACHE_DEFAULT_TIMEOUT": 30})
 

--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -373,13 +373,13 @@ class Config(object):
 
     def __validate(self):
         # We expect IPFS and API key service to be up already
-        if not is_service_reachable(self.session, self.ipfs_uri):
+        if not is_service_reachable(self.session, f"{self.ipfs_uri}/api/v0/bootstrap"):
             raise ValueError('IPFS not reachable, is correct URI specified?')
 
         if self.artifact_limit < 1 or self.artifact_limit > 256:
             raise ValueError('Artifact limit must be greater than 0 and cannot exceed contract limit of 256')
 
-        if self.auth_uri and not is_service_reachable(self.session, self.auth_uri):
+        if self.auth_uri and not is_service_reachable(self.session, f"{self.auth_uri}/communities/public"):
             raise ValueError('API key service not reachable, is correct URI specified?')
 
         if self.require_api_key and not self.auth_uri:


### PR DESCRIPTION
Address some observed performance issues on prod.

This PR does two main things:
1. Ensures that status checks fail if our HTTP sessions are hanging, rather than just checking for open ports. The downside to this is that it will restart `polyswarmd` if other services are not responding as well, but at this point `polyswarmd` is essentially non-functional anyway.
2. Increases the number of HTTP client workers, sets a low timeout, and lowers the number of retries so that hanging queries don't block execution. 