### PR TITLE
Wipe the verdicts with None values when there was no reveal

### DIFF
--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -421,7 +421,7 @@ def get_bounties_guid_assertions(guid):
                 g.chain.bounty_registry.contract.functions.assertionsByGuid(guid.int, i).call(),
                 bounty['num_artifacts'])
             # Nonce is 0 when a reveal did not occur
-            if assertion['nonce'] == 0:
+            if assertion['nonce'] == "0":
                 assertion['verdicts'] = [None] * bounty['num_artifacts']
             assertion['metadata'] = substitute_ipfs_metadata(assertion.get('metadata', ''))
             assertions.append(assertion)

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -422,7 +422,7 @@ def get_bounties_guid_assertions(guid):
                 bounty['num_artifacts'])
             # Nonce is 0 when a reveal did not occur
             if assertion['nonce'] == 0:
-                assertion['verdict'] = [None] * bounty['num_artifacts']
+                assertion['verdicts'] = [None] * bounty['num_artifacts']
             assertion['metadata'] = substitute_ipfs_metadata(assertion.get('metadata', ''))
             assertions.append(assertion)
         except Exception:

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -420,6 +420,9 @@ def get_bounties_guid_assertions(guid):
             assertion = assertion_to_dict(
                 g.chain.bounty_registry.contract.functions.assertionsByGuid(guid.int, i).call(),
                 bounty['num_artifacts'])
+            # Nonce is 0 when a reveal did not occur
+            if assertion['nonce'] == 0:
+                assertion['verdict'] = [None] * bounty['num_artifacts']
             assertion['metadata'] = substitute_ipfs_metadata(assertion.get('metadata', ''))
             assertions.append(assertion)
         except Exception:


### PR DESCRIPTION
polyswarmd returns verdict values even when the engine did not reveal the assertion. While an accurate portrayal of the uint256 in the contract, it is confusing for anything that hits this endpoint. 

This change will return a list of nulls as verdict values when there was no reveal. 