### PR TITLE
Move Geth RPC to separate greenlet 

### DIFF
--- a/src/polyswarmd/artifacts.py
+++ b/src/polyswarmd/artifacts.py
@@ -82,12 +82,15 @@ def post_to_ipfs(files, wrap_dir=False):
     return 201, json.loads(r.text.splitlines()[-1])['Hash']
 
 
-def get_from_ipfs(ipfs_uri):
-    config = app.config['POLYSWARMD']
-    session = app.config['REQUESTS_SESSION']
+def get_from_ipfs(ipfs_uri, ipfs_root=None, session=None):
+    if not ipfs_root:
+        ipfs_root = app.config['POLYSWARMD'].ipfs_uri
+
+    if not session:
+        session = app.config['REQUESTS_SESSION']
 
     try:
-        future = session.get(config.ipfs_uri + '/api/v0/cat', params={'arg': ipfs_uri}, timeout=1)
+        future = session.get(ipfs_root + '/api/v0/cat', params={'arg': ipfs_uri}, timeout=1)
         r = future.result()
         r.raise_for_status()
     except requests.exceptions.HTTPError as e:

--- a/src/polyswarmd/balances.py
+++ b/src/polyswarmd/balances.py
@@ -8,6 +8,7 @@ from polyswarmd.response import success, failure
 logger = logging.getLogger(__name__)
 balances = Blueprint('balances', __name__)
 
+
 @balances.route('/<address>/eth', methods=['GET'])
 @chain(account_required=False)
 def get_balance_address_eth(address):
@@ -21,6 +22,7 @@ def get_balance_address_eth(address):
     except Exception:
         logger.exception('Unexpected exception retrieving ETH balance')
         return failure("Could not retrieve balance")
+
 
 @balances.route('/<address>/staking/total', methods=['GET'])
 @chain(account_required=False)

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -1,7 +1,7 @@
 import json
+import jsonschema
 import logging
 import os
-import jsonschema
 import uuid
 
 from ethereum.utils import sha3
@@ -55,7 +55,8 @@ def calculate_commitment(account, verdicts):
 
 @cache.memoize(30)
 def substitute_ipfs_metadata(ipfs_uri, validate=AssertionMetadata.validate, ipfs_root=None, session=None):
-    """Download metadata from IPFS and validate it against the schema.
+    """
+    Download metadata from IPFS and validate it against the schema.
 
     :param ipfs_uri: Potential IPFS uri string
     :param validate: Function that takes a loaded json blob and returns true if it matches the schema

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -188,7 +188,6 @@ def get_bounty_parameters():
 
 
 @bounties.route('/<uuid:guid>', methods=['GET'])
-@cache.memoize(1)
 @chain
 def get_bounties_guid(guid):
     bounty = bounty_to_dict(
@@ -409,7 +408,6 @@ def post_bounties_guid_assertions_id_reveal(guid, id_):
 
 
 @bounties.route('/<uuid:guid>/assertions', methods=['GET'])
-@cache.memoize(1)
 @chain
 def get_bounties_guid_assertions(guid):
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
@@ -434,7 +432,6 @@ def get_bounties_guid_assertions(guid):
 
 
 @bounties.route('/<uuid:guid>/assertions/<int:id_>', methods=['GET'])
-@cache.memoize(1)
 @chain
 def get_bounties_guid_assertions_id(guid, id_):
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
@@ -452,7 +449,6 @@ def get_bounties_guid_assertions_id(guid, id_):
 
 
 @bounties.route('/<uuid:guid>/votes', methods=['GET'])
-@cache.memoize(1)
 @chain
 def get_bounties_guid_votes(guid):
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
@@ -476,7 +472,6 @@ def get_bounties_guid_votes(guid):
 
 
 @bounties.route('/<uuid:guid>/votes/<int:id_>', methods=['GET'])
-@cache.memoize(1)
 @chain
 def get_bounties_guid_votes_id(guid, id_):
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -54,17 +54,19 @@ def calculate_commitment(account, verdicts):
 
 
 @cache.memoize(30)
-def substitute_ipfs_metadata(ipfs_uri, validate=AssertionMetadata.validate):
+def substitute_ipfs_metadata(ipfs_uri, validate=AssertionMetadata.validate, ipfs_root=None, session=None):
     """Download metadata from IPFS and validate it against the schema.
 
     :param ipfs_uri: Potential IPFS uri string
     :param validate: Function that takes a loaded json blob and returns true if it matches the schema
+    :param ipfs_root: Root uri for ipfs
+    :param session: Requests session for ipfs request
     :return: Metadata from IPFS, or original metadata
     """
     if not is_valid_ipfshash(ipfs_uri):
         return ipfs_uri
 
-    status_code, content = get_from_ipfs(ipfs_uri)
+    status_code, content = get_from_ipfs(ipfs_uri, ipfs_root=ipfs_root, session=session)
     try:
         if status_code // 100 == 2 and validate(json.loads(content.decode('utf-8'))):
             return json.loads(content.decode('utf-8'))

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -1,4 +1,3 @@
-import functools
 import json
 import logging
 import os
@@ -54,7 +53,7 @@ def calculate_commitment(account, verdicts):
     return int_from_bytes(nonce), int_from_bytes(commitment)
 
 
-@functools.lru_cache(maxsize=256)
+@cache.memoize(30)
 def substitute_ipfs_metadata(ipfs_uri, validate=AssertionMetadata.validate):
     """Download metadata from IPFS and validate it against the schema.
 
@@ -161,6 +160,7 @@ def post_bounties():
 
 
 @bounties.route('/parameters', methods=['GET'])
+@cache.memoize(1)
 @chain
 def get_bounty_parameters():
     bounty_fee = g.chain.bounty_registry.contract.functions.bountyFee().call()
@@ -185,6 +185,7 @@ def get_bounty_parameters():
 
 
 @bounties.route('/<uuid:guid>', methods=['GET'])
+@cache.memoize(1)
 @chain
 def get_bounties_guid(guid):
     bounty = bounty_to_dict(
@@ -405,7 +406,7 @@ def post_bounties_guid_assertions_id_reveal(guid, id_):
 
 
 @bounties.route('/<uuid:guid>/assertions', methods=['GET'])
-@cache.memoize(30)
+@cache.memoize(1)
 @chain
 def get_bounties_guid_assertions(guid):
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
@@ -430,7 +431,7 @@ def get_bounties_guid_assertions(guid):
 
 
 @bounties.route('/<uuid:guid>/assertions/<int:id_>', methods=['GET'])
-@cache.memoize(30)
+@cache.memoize(1)
 @chain
 def get_bounties_guid_assertions_id(guid, id_):
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
@@ -448,6 +449,7 @@ def get_bounties_guid_assertions_id(guid, id_):
 
 
 @bounties.route('/<uuid:guid>/votes', methods=['GET'])
+@cache.memoize(1)
 @chain
 def get_bounties_guid_votes(guid):
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
@@ -471,6 +473,7 @@ def get_bounties_guid_votes(guid):
 
 
 @bounties.route('/<uuid:guid>/votes/<int:id_>', methods=['GET'])
+@cache.memoize(1)
 @chain
 def get_bounties_guid_votes_id(guid, id_):
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
@@ -486,6 +489,7 @@ def get_bounties_guid_votes_id(guid, id_):
 
 
 @bounties.route('/<uuid:guid>/bloom', methods=['GET'])
+@cache.memoize(30)
 @chain
 def get_bounties_guid_bloom(guid):
     bounty = bounty_to_dict(g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())

--- a/src/polyswarmd/chains.py
+++ b/src/polyswarmd/chains.py
@@ -7,8 +7,10 @@ from polyswarmd.response import failure
 
 logger = logging.getLogger(__name__)
 
+
 def chain(_func=None, chain_name=None, account_required=True):
-    """This decorator takes the chain passed as a request arg and modifies a set of globals.
+    """
+    This decorator takes the chain passed as a request arg and modifies a set of globals.
        There are a few guarantees made by this function.
 
        If any of the values for the given chain are missing, the decorator will skip the function and return an error to the user. (500)

--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -18,6 +18,7 @@ from web3.middleware import geth_poa_middleware
 
 from polyswarmd.eth import ZERO_ADDRESS
 from polyswarmd.utils import camel_case_to_snake_case
+from polyswarmd.rpc import GethRpc
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,7 @@ class ChainConfig(object):
         self.erc20_relay = erc20_relay
         self.offer_registry = offer_registry
         self.offer_multisig = offer_multisig
+        self.rpc = GethRpc(self)
 
         self.free = free
         self.config_filename = ''

--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -18,7 +18,7 @@ from web3.middleware import geth_poa_middleware
 
 from polyswarmd.eth import ZERO_ADDRESS
 from polyswarmd.utils import camel_case_to_snake_case
-from polyswarmd.rpc import GethRpc
+from polyswarmd.rpc import EthereumRpc
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +154,7 @@ class ChainConfig(object):
         self.erc20_relay = erc20_relay
         self.offer_registry = offer_registry
         self.offer_multisig = offer_multisig
-        self.rpc = GethRpc(self)
+        self.rpc = EthereumRpc(self)
 
         self.free = free
         self.config_filename = ''

--- a/src/polyswarmd/offers.py
+++ b/src/polyswarmd/offers.py
@@ -577,7 +577,7 @@ def get_websocket(guid):
 
     if not validate_ws_url(socket_uri):
         return failure(
-            'Contract does not have a valid websocket uri',
+            'Contract does not have a valid WebSocket uri',
             400)
 
     return success({'websocket': socket_uri})

--- a/src/polyswarmd/relay.py
+++ b/src/polyswarmd/relay.py
@@ -11,11 +11,13 @@ from polyswarmd.eth import build_transaction
 logger = logging.getLogger(__name__)
 relay = Blueprint('relay', __name__)
 
+
 @relay.route('/deposit', methods=['POST'])
 @chain(chain_name='home')
 def deposit_funds():
     # Move funds from home to side
     return send_funds_from()
+
 
 @relay.route('/withdrawal', methods=['POST'])
 @chain(chain_name='side')
@@ -23,10 +25,12 @@ def withdraw_funds():
     # Move funds from side to home
     return send_funds_from()
 
+
 @relay.route('/fees', methods=['GET'])
 @chain
 def fees():
     return success({'fees': g.chain.erc20_relay.functions.fees().call()})
+
 
 def send_funds_from():
     # Grab correct versions by chain type

--- a/src/polyswarmd/rpc.py
+++ b/src/polyswarmd/rpc.py
@@ -69,8 +69,7 @@ class EthereumRpc:
         self.setup_filters()
         from polyswarmd.bounties import substitute_ipfs_metadata
         while True:
-            gevent.sleep(1)
-            # If there is no websocket, don't sleep loop, just exit
+            # If there is no websocket, exit greenlet
             with self.websockets_lock:
                 if not self.websockets:
                     # Set websockets to None so the greenlet is recreated on new join

--- a/src/polyswarmd/rpc.py
+++ b/src/polyswarmd/rpc.py
@@ -1,0 +1,237 @@
+import gevent
+import json
+
+from gevent.lock import BoundedSemaphore
+from requests.exceptions import ConnectionError
+from polyswarmartifact.schema import Bounty as BountyMetadata
+from polyswarmd.utils import *
+
+
+class GethRpc:
+    """
+    This class periodically polls several geth filters, and multicasts the results across any open websockets
+
+    """
+    def __init__(self, chain):
+        self.chain = chain
+        self.assertion_filter = None
+        self.block_filter = None
+        self.bounty_filter = None
+        self.deprecated_filter = None
+        self.fee_filter = None
+        self.init_filter = None
+        self.quorum_filiter = None
+        self.reveal_filter = None
+        self.settled_filter = None
+        self.vote_filter = None
+        self.window_filter = None
+        self.websockets_lock = BoundedSemaphore(1)
+        self.websockets = None
+
+    def broadcast(self, message):
+        logger.debug('Sending: %s', message)
+        try:
+            self.websockets_lock.acquire()
+            for ws in self.websockets:
+                logger.critical('Sending ws %s %s', ws, message)
+                ws.send(json.dumps(message))
+        finally:
+            self.websockets_lock.release()
+
+    def flush_filters(self):
+        self.block_filter.get_new_entries()
+        self.fee_filter.get_new_entries()
+        self.window_filter.get_new_entries()
+        self.bounty_filter.get_new_entries()
+        self.assertion_filter.get_new_entries()
+        self.vote_filter.get_new_entries()
+        self.quorum_filiter.get_new_entries()
+        self.settled_filter.get_new_entries()
+        self.reveal_filter.get_new_entries()
+        self.deprecated_filter.get_new_entries()
+        if self.init_filter:
+            self.init_filter.get_new_entries()
+
+    # noinspection PyBroadException
+    def poll(self):
+        from polyswarmd.bounties import substitute_ipfs_metadata
+        self.setup_filters()
+        while True:
+            gevent.sleep(1)
+            # Check that there is some websocket connection
+            try:
+                self.websockets_lock.acquire()
+                skip = not self.websockets
+            finally:
+                self.websockets_lock.release()
+
+            # If there isn't, hit the filters anyway, since we don't want old data
+            if skip:
+                continue
+
+            try:
+                for event in self.fee_filter.get_new_entries():
+                    fee_update = {
+                        'event': 'fee_update',
+                        'data': fee_update_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex(),
+                    }
+                    self.broadcast(fee_update)
+
+                for event in self.window_filter.get_new_entries():
+                    window_update = {
+                        'event': 'window_update',
+                        'data': window_update_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex(),
+                    }
+                    self.broadcast(window_update)
+
+                for event in self.bounty_filter.get_new_entries():
+                    bounty = {
+                        'event': 'bounty',
+                        'data': new_bounty_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex(),
+                    }
+                    metadata = bounty['data'].get('metadata', None)
+                    if metadata:
+                        bounty['data']['metadata'] = substitute_ipfs_metadata(metadata, BountyMetadata.validate)
+                    else:
+                        bounty['data']['metadata'] = None
+
+                    self.broadcast(bounty)
+
+                for event in self.assertion_filter.get_new_entries():
+                    assertion = {
+                        'event': 'assertion',
+                        'data': new_assertion_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex(),
+                    }
+                    self.broadcast(assertion)
+
+                for event in self.reveal_filter.get_new_entries():
+                    reveal = {
+                        'event': 'reveal',
+                        'data': revealed_assertion_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex(),
+                    }
+                    reveal['data']['metadata'] = substitute_ipfs_metadata(reveal['data'].get('metadata', ''))
+
+                    self.broadcast(reveal)
+
+                for event in self.vote_filter.get_new_entries():
+                    vote = {
+                        'event': 'vote',
+                        'data': new_vote_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex(),
+                    }
+                    self.broadcast(vote)
+
+                for event in self.quorum_filiter.get_new_entries():
+                    quorum = {
+                        'event': 'quorum',
+                        'data': new_quorum_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex(),
+                    }
+                    self.broadcast(quorum)
+
+                for event in self.settled_filter.get_new_entries():
+                    settled_bounty = {
+                        'event': 'settled_bounty',
+                        'data': settled_bounty_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex(),
+                    }
+                    self.broadcast(settled_bounty)
+
+                for event in self.deprecated_filter.get_new_entries():
+                    deprecated = {
+                        'event': 'deprecated',
+                        'data': deprecated_event_to_dict(event.args),
+                        'block_number': event.blockNumber,
+                        'txhash': event.transactionHash.hex()
+                    }
+                    self.broadcast(deprecated)
+
+                if self.init_filter is not None:
+                    for event in self.init_filter.get_new_entries():
+                        initialized_channel = {
+                            'event': 'initialized_channel',
+                            'data': new_init_channel_event_to_dict(event.args),
+                            'block_number': event.blockNumber,
+                            'txhash': event.transactionHash.hex(),
+                        }
+                        self.broadcast(initialized_channel)
+                for _ in self.block_filter.get_new_entries():
+                    block = {
+                        'event': 'block',
+                        'data': {
+                            'number': self.chain.w3.eth.blockNumber,
+                        },
+                    }
+                    self.broadcast(block)
+            except ConnectionError:
+                logger.exception('ConnectionError in filters (is geth down?)')
+                continue
+            except Exception:
+                logger.exception('Exception in filter checks, resetting filters')
+                self.flush_filters()
+                continue
+
+    def register(self, ws):
+        """
+        Register a websocket with the rpc nodes
+        Gets all events going forward
+        :param ws: websocket to send to
+        """
+        # Cross greenlet communication here
+        start = False
+        try:
+            self.websockets_lock.acquire()
+            if self.websockets is None:
+                start = True
+                self.websockets = []
+            elif not self.websockets:
+                # Clear the filters of old data
+                logger.critical('Clearing out of date filter events.')
+                self.flush_filters()
+
+            self.websockets.append(ws)
+        finally:
+            self.websockets_lock.release()
+
+        if start:
+            logger.debug('First websocket registered, starting greenlet')
+            gevent.spawn(self.poll)
+
+    def setup_filters(self):
+        self.block_filter = self.chain.w3.eth.filter('latest')
+        self.fee_filter = self.chain.bounty_registry.contract.eventFilter('FeesUpdated')
+        self.window_filter = self.chain.bounty_registry.contract.eventFilter('WindowsUpdated')
+        self.bounty_filter = self.chain.bounty_registry.contract.eventFilter('NewBounty')
+        self.assertion_filter = self.chain.bounty_registry.contract.eventFilter('NewAssertion')
+        self.vote_filter = self.chain.bounty_registry.contract.eventFilter('NewVote')
+        self.quorum_filiter = self.chain.bounty_registry.contract.eventFilter('QuorumReached')
+        self.settled_filter = self.chain.bounty_registry.contract.eventFilter('SettledBounty')
+        self.reveal_filter = self.chain.bounty_registry.contract.eventFilter('RevealedAssertion')
+        self.deprecated_filter = self.chain.bounty_registry.contract.eventFilter('Deprecated')
+        self.init_filter = None
+        if self.chain.offer_registry.contract is not None:
+            self.init_filter = self.chain.offer_registry.contract.eventFilter('InitializedChannel')
+
+    def unregister(self, ws):
+        logger.debug('Unregistering websocket %s', ws)
+        try:
+            self.websockets_lock.acquire()
+            if ws in self.websockets:
+                logger.critical('Removing ws %s', ws)
+                self.websockets.remove(ws)
+
+        finally:
+            self.websockets_lock.release()

--- a/src/polyswarmd/utils.py
+++ b/src/polyswarmd/utils.py
@@ -243,7 +243,8 @@ def camel_case_to_snake_case(s):
 
 
 def to_padded_hex(val: Union[str, bool, int, bytes]) -> str:
-    """Convert an argument to a hexadecimal string and zero-extend to 64 width"""
+    """
+    Convert an argument to a hexadecimal string and zero-extend to 64 width"""
     def encode_hex(xs: bytes) -> str:
         return codecs.encode(xs, "hex").decode("ascii") # type: ignore
 

--- a/src/polyswarmd/websockets.py
+++ b/src/polyswarmd/websockets.py
@@ -22,21 +22,12 @@ class Websocket:
         self.queue_lock = BoundedSemaphore(1)
 
     def send(self, message):
-        try:
-            self.queue_lock.acquire()
+        with self.queue_lock:
             self.queue.append(message)
-        finally:
-            self.queue_lock.release()
 
     def get_messages(self):
-        try:
-            self.queue_lock.acquire()
+        with self.queue_lock:
             messages = [msg for msg in self.queue]
-        except:
-            logger.exception('Failed to get messages in websocket')
-            messages = []
-        finally:
-            self.queue_lock.release()
 
         return messages
 

--- a/src/polyswarmd/websockets.py
+++ b/src/polyswarmd/websockets.py
@@ -57,16 +57,15 @@ def init_websockets(app):
         while not ws.closed:
             try:
                 msg = wrapper.queue.get(block=False)
-                try:
-                    ws.send(msg)
-                except WebSocketError as e:
-                    logger.error('Websocket %s closed %s', wrapper, e)
-                    rpc.unregister(wrapper)
-                    return
+                ws.send(msg)
             except Empty:
                 with gevent.Timeout(.5, False):
                     logger.debug('Checking %s against timeout', wrapper)
                     ws.receive()
+            except WebSocketError as e:
+                logger.error('Websocket %s closed %s', wrapper, e)
+                rpc.unregister(wrapper)
+                return
 
         rpc.unregister(wrapper)
 

--- a/src/polyswarmd/websockets.py
+++ b/src/polyswarmd/websockets.py
@@ -6,7 +6,6 @@ import time
 from gevent.queue import Queue, Empty
 
 from flask_sockets import Sockets
-from gevent.lock import BoundedSemaphore
 from geventwebsocket import WebSocketError
 from jsonschema.exceptions import ValidationError
 from requests.exceptions import ConnectionError


### PR DESCRIPTION
After fooling around with Flask-SocketIO, and realizing the uwsgi integration isn't as good as we believed, I tried for the simpler, backwards compatible change that should get us the performance gains we wanted. 

This moves the filter polling loop into a long-running greenlet that broadcasts to all connected websockets. Because it has cross-greenlet communications with the main per connection greenlets we had to use some semaphores to protect the registered list. 

The main idea here is to only run at most a single greenlet per gunicorn worker. Once a websocket connects we establish the filters. We can't close the filters (from what I have seen) so if we drop down to 0 websockets, the next new connection will trigger a flush of existing filter changes that occurred before the websocket connection. 
That way we aren't polling constantly when nobody is listening. 


It still has some problems. 
Namely,
- [x] Cross greenlet access to config in substitute ipfs metadata
- [x] Need docstrings on the new functions and classes