### PR TITLE
Stop estimating gas on free chains

### DIFF
--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -79,6 +79,10 @@ def wait_for_consul_key_deletion(client, key, recurse=False, index=0):
             continue
 
 
+def free_gas_strategy(web3, tx_params):
+    return Web3.toWei(0)
+
+
 class ContractConfig(object):
     def __init__(self, w3, name, abi, address=None):
         self.name = name
@@ -180,6 +184,9 @@ class ChainConfig(object):
         w3 = Web3(HTTPProvider(eth_uri))
         w3.middleware_stack.inject(geth_poa_middleware, layer=0)
 
+        if free:
+            w3.eth.setGasPriceStrategy(free_gas_strategy)
+
         contract_configs = {}
 
         contracts_dir = os.path.join(os.path.dirname(filename), 'contracts')
@@ -213,6 +220,9 @@ class ChainConfig(object):
         free = config.get('free', False)
         w3 = Web3(HTTPProvider(eth_uri))
         w3.middleware_stack.inject(geth_poa_middleware, layer=0)
+
+        if free:
+            w3.eth.setGasPriceStrategy(free_gas_strategy)
 
         # TODO schema check json
         expected_contracts = ['NectarToken', 'BountyRegistry', 'ArbiterStaking', 'ERC20Relay', 'OfferRegistry',

--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -79,10 +79,6 @@ def wait_for_consul_key_deletion(client, key, recurse=False, index=0):
             continue
 
 
-def free_gas_strategy(web3, tx_params):
-    return Web3.toWei(0)
-
-
 class ContractConfig(object):
     def __init__(self, w3, name, abi, address=None):
         self.name = name
@@ -184,9 +180,6 @@ class ChainConfig(object):
         w3 = Web3(HTTPProvider(eth_uri))
         w3.middleware_stack.inject(geth_poa_middleware, layer=0)
 
-        if free:
-            w3.eth.setGasPriceStrategy(free_gas_strategy)
-
         contract_configs = {}
 
         contracts_dir = os.path.join(os.path.dirname(filename), 'contracts')
@@ -220,9 +213,6 @@ class ChainConfig(object):
         free = config.get('free', False)
         w3 = Web3(HTTPProvider(eth_uri))
         w3.middleware_stack.inject(geth_poa_middleware, layer=0)
-
-        if free:
-            w3.eth.setGasPriceStrategy(free_gas_strategy)
 
         # TODO schema check json
         expected_contracts = ['NectarToken', 'BountyRegistry', 'ArbiterStaking', 'ERC20Relay', 'OfferRegistry',

--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -208,6 +208,7 @@ def post_transactions():
 
     return success(results)
 
+
 def build_transaction(call, nonce):
     options = {
         'nonce': nonce,
@@ -217,12 +218,15 @@ def build_transaction(call, nonce):
 
     if g.chain.free:
         options["gasPrice"] = 0
+        gas = MAX_GAS_LIMIT
+    else:
+        try:
+            gas = int(call.estimateGas({'from': g.eth_address, **options}) * GAS_MULTIPLIER)
+        except ValueError as e:
+            logger.debug('Error estimating gas, using default: %s', e)
+            gas = MAX_GAS_LIMIT
 
-    try:
-        gas = int(call.estimateGas({'from': g.eth_address, **options}) * GAS_MULTIPLIER)
-        options['gas'] = min(MAX_GAS_LIMIT, gas)
-    except ValueError as e:
-        logger.debug('Error estimating gas, using default: %s', e)
+    options['gas'] = min(MAX_GAS_LIMIT, gas)
 
     logger.info('options: %s', options)
 


### PR DESCRIPTION
`estimateGas` chews up a lot of `geth-rpc` time. Don't query this when the answer is 0.