### PR TITLE
Use PyPy instead of CPython

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-jessie
+FROM pypy:3.6-jessie
 LABEL maintainer="PolySwarm Developers <info@polyswarm.io>"
 
 WORKDIR /usr/src/app
@@ -17,4 +17,4 @@ COPY . .
 RUN set -x && pip install .
 
 # You can set log format and level in command line by e.g. `polyswarmd.wsgi:app(log_format='text', log_level='WARNING')`
-CMD ["gunicorn", "--bind", "0.0.0.0:31337", "-k", "flask_sockets.worker", "-t", "600", "-w", "4", "polyswarmd.wsgi:app()"]
+CMD ["pypy3", "/usr/local/bin/gunicorn", "--bind", "0.0.0.0:31337", "-k", "flask_sockets.worker", "-t", "600", "-w", "4", "polyswarmd.wsgi:app()"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM pypy:3.6-jessie
+FROM pypy:3.6-7.0-jessie
 LABEL maintainer="PolySwarm Developers <info@polyswarm.io>"
 
 WORKDIR /usr/src/app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 base58==0.2.5
 python-consul==1.1.0
 click==7.0
-ethereum==2.3.2
+py-evm==0.3.0a5
 gevent==1.2.2
 gevent-websocket==0.10.1
 jsonschema==2.6.0
 Flask==1.0.2
 Flask-Caching==1.7.2
 Flask-Sockets==0.2.1
-polyswarm-artifact==1.2.0
+polyswarm-artifact==1.2.1
 psycopg2-binary==2.7.6.1
 PyYaml==4.2b4
 pytest== 4.0.0
@@ -17,7 +17,8 @@ requests==2.20.1
 requests-futures==0.9.9
 requests-mock==1.5.0
 rlp==1.1.0
-web3==4.8.1
+web3==4.9.2
 websocket-client==0.48.0
 Werkzeug==0.14.1
+pycryptodome==3.8.1
 git+https://github.com/polyswarm/flask-profiler.git@profile-stats#egg=flask_profiler

--- a/src/polyswarmd/bloom.py
+++ b/src/polyswarmd/bloom.py
@@ -4,7 +4,7 @@ import logging
 import numbers
 import operator
 
-from ethereum.utils import sha3
+from .utils import sha3
 
 logger = logging.getLogger(__name__)
 

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -4,7 +4,6 @@ import logging
 import os
 import uuid
 
-from ethereum.utils import sha3
 from flask import Blueprint, g, request
 from jsonschema.exceptions import ValidationError
 from polyswarmartifact import ArtifactType
@@ -16,7 +15,7 @@ from polyswarmd.chains import chain
 from polyswarmd.bloom import BloomFilter, FILTER_BITS
 from polyswarmd.eth import build_transaction, ZERO_ADDRESS
 from polyswarmd.response import success, failure
-from polyswarmd.utils import bool_list_to_int, bounty_to_dict, assertion_to_dict, vote_to_dict, bloom_to_dict
+from polyswarmd.utils import bool_list_to_int, bounty_to_dict, assertion_to_dict, vote_to_dict, bloom_to_dict, sha3
 
 logger = logging.getLogger(__name__)
 bounties = Blueprint('bounties', __name__)

--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -6,7 +6,9 @@ import rlp
 from collections import defaultdict
 from eth_abi import decode_abi
 from eth_abi.exceptions import InsufficientDataBytes
-from ethereum.transactions import Transaction
+from eth.vm.forks.constantinople.transactions import (
+    ConstantinopleTransaction
+)
 from flask import current_app as app, Blueprint, g, request
 from hexbytes import HexBytes
 from jsonschema.exceptions import ValidationError
@@ -156,7 +158,7 @@ def post_transactions():
     results = []
     for raw_tx in body['transactions']:
         try:
-            tx = rlp.decode(bytes.fromhex(raw_tx), Transaction)
+            tx = rlp.decode(bytes.fromhex(raw_tx), ConstantinopleTransaction)
         except ValueError as e:
             logger.error('Invalid transaction: %s', e)
             continue

--- a/src/polyswarmd/utils.py
+++ b/src/polyswarmd/utils.py
@@ -3,7 +3,8 @@ import logging
 import string
 import re
 import uuid
-from typing import AnyStr, Union
+from typing import Union
+from Crypto.Hash import keccak
 
 from flask import g
 from polyswarmartifact import ArtifactType
@@ -337,3 +338,9 @@ def validate_ws_url(uri):
         r'(?:/?|[/?]\S+)$', re.IGNORECASE)
 
     return re.match(regex, uri) is not None
+
+
+def sha3(data):
+    h = keccak.new(digest_bits=256)
+    h.update(data)
+    return h.digest()


### PR DESCRIPTION
This pull request adds support for PyPy by removing older, unmaintained deps on the `pyethereum` package.

A couple notes:
* This uses an older version of PyPy than the most recent release. They introduced a bug in the `codec` module that is currently fixed in master, but there hasn't been a new release since then.
* `pyethereum` functionality was replaced with `py-evm` and `pycryptodome`. `py-evm` is still alpha but we just need it for the `rlp` transaction decoder, which seems to work just fine. `pycroptodome` version is one behind latest, to match `web3.py`.