### PR TITLE
remove pypy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM pypy:3.6-7.0-jessie
+FROM python:3.6-jessie
 LABEL maintainer="PolySwarm Developers <info@polyswarm.io>"
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
PyPy requires further testing, as we are observing stability/memory usage issues.