### PR TITLE
change to match portal-backend

### DIFF
--- a/src/polyswarmd/artifacts.py
+++ b/src/polyswarmd/artifacts.py
@@ -14,7 +14,7 @@ artifacts = Blueprint('artifacts', __name__)
 # 100MB limit
 # TODO: Should this be configurable in config file?
 MAX_ARTIFACT_SIZE_REGULAR = 32 * 1024 * 1024
-MAX_ARTIFACT_SIZE_ANONYMOUS = 2 * 1024 * 1024
+MAX_ARTIFACT_SIZE_ANONYMOUS = 10 * 1024 * 1024
 
 
 def is_valid_ipfshash(ipfshash):


### PR DESCRIPTION
We increased the anonymous user upload limit, but didn't increase it here. This results in bounties that appear to hang indefinitely if the user isn't logged in.