### PR TITLE
Read artifact size limits from api key mgmt

### DIFF
--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -91,9 +91,12 @@ class User(object):
 
         anonymous = j.get('anonymous', True)
         user_id = j.get('user_id') if not anonymous else None
-        max_artifact_size = j.get('max_artifact_size', FALLBACK_MAX_ARTIFACT_SIZE)
+        max_artifact_size = next(
+            (f['base_uses'] for f in j.get('features', []) if f['tag'] == 'max_artifact_size'),
+            FALLBACK_MAX_ARTIFACT_SIZE
+        )
 
-        return cls(authorized=True, user_id=user_id, max_artifact_size=max_artifact_size, )
+        return cls(authorized=True, user_id=user_id, max_artifact_size=max_artifact_size)
 
     @property
     def anonymous(self):

--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -67,7 +67,7 @@ def get_auth(api_key, auth_uri):
 
 
 class User(object):
-    def __init__(self, max_artifact_size, authorized=False, user_id=None):
+    def __init__(self, authorized=False, user_id=None, max_artifact_size=FALLBACK_MAX_ARTIFACT_SIZE):
         self.authorized = authorized
         self.max_artifact_size = max_artifact_size
         self.user_id = user_id if authorized else None
@@ -81,19 +81,19 @@ class User(object):
 
         r = get_auth(api_key, auth_uri)
         if r is None or r.status_code != 200:
-            return cls(FALLBACK_MAX_ARTIFACT_SIZE, authorized=False, user_id=None)
+            return cls(authorized=False, user_id=None, max_artifact_size=FALLBACK_MAX_ARTIFACT_SIZE)
 
         try:
             j = r.json()
         except ValueError:
             logger.exception('Invalid response from API key management service, received: %s', r.content)
-            return cls(FALLBACK_MAX_ARTIFACT_SIZE, authorized=False, user_id=None)
+            return cls(authorized=False, user_id=None, max_artifact_size=FALLBACK_MAX_ARTIFACT_SIZE)
 
         anonymous = j.get('anonymous', True)
         user_id = j.get('user_id') if not anonymous else None
         max_artifact_size = j.get('max_artifact_size', FALLBACK_MAX_ARTIFACT_SIZE)
 
-        return cls(max_artifact_size, authorized=True, user_id=user_id)
+        return cls(authorized=True, user_id=user_id, max_artifact_size=max_artifact_size, )
 
     @property
     def anonymous(self):
@@ -138,7 +138,7 @@ def status():
 
 @app.before_request
 def before_request():
-    g.user = User(FALLBACK_MAX_ARTIFACT_SIZE)
+    g.user = User()
 
     config = app.config['POLYSWARMD']
 

--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -138,7 +138,7 @@ def status():
 
 @app.before_request
 def before_request():
-    g.user = User()
+    g.user = User(FALLBACK_MAX_ARTIFACT_SIZE)
 
     config = app.config['POLYSWARMD']
 

--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -11,7 +11,7 @@ import functools
 from flask import Flask, g, request
 from flask_caching import Cache
 
-from polyswarmd.config import Config, is_service_reachable
+from polyswarmd.config import Config, is_service_reachable, DEFAULT_FALLBACK_SIZE
 from polyswarmd.logger import init_logging
 from polyswarmd.profiler import setup_profiler
 from polyswarmd.response import success, failure, install_error_handlers
@@ -67,10 +67,11 @@ def get_auth(api_key, auth_uri):
 
 
 class User(object):
-    def __init__(self, authorized=False, user_id=None, max_artifact_size=1):
+    def __init__(self, authorized=False, user_id=None, max_artifact_size=DEFAULT_FALLBACK_SIZE):
         self.authorized = authorized
         self.max_artifact_size = max_artifact_size
         self.user_id = user_id if authorized else None
+        logger.critical('MAX SIZE IS %s', max_artifact_size)
 
     @classmethod
     def from_api_key(cls, api_key):
@@ -78,6 +79,8 @@ class User(object):
         session = app.config['REQUESTS_SESSION']
 
         auth_uri = f'{config.auth_uri}/communities/{config.community}/auth'
+
+        logger.critical('FALLBACK IS %s', config.fallback_max_artifact_size)
 
         r = get_auth(api_key, auth_uri)
         if r is None or r.status_code != 200:

--- a/src/polyswarmd/artifacts/artifacts.py
+++ b/src/polyswarmd/artifacts/artifacts.py
@@ -10,9 +10,6 @@ from polyswarmd.response import success, failure
 logger = logging.getLogger(__name__)
 artifacts = Blueprint('artifacts', __name__)
 
-# 10 MB Fallback limit
-FALLBACK_MAX_ARTIFACT_SIZE = 10 * 1024 * 1024
-
 
 @artifacts.route('/status', methods=['GET'])
 def get_artifacts_status():

--- a/src/polyswarmd/artifacts/artifacts.py
+++ b/src/polyswarmd/artifacts/artifacts.py
@@ -10,10 +10,8 @@ from polyswarmd.response import success, failure
 logger = logging.getLogger(__name__)
 artifacts = Blueprint('artifacts', __name__)
 
-# 100MB limit
-# TODO: Should this be configurable in config file?
-MAX_ARTIFACT_SIZE_REGULAR = 32 * 1024 * 1024
-MAX_ARTIFACT_SIZE_ANONYMOUS = 10 * 1024 * 1024
+# 10 MB Fallback limit
+FALLBACK_MAX_ARTIFACT_SIZE = 10 * 1024 * 1024
 
 
 @artifacts.route('/status', methods=['GET'])
@@ -35,6 +33,7 @@ def post_artifacts():
     config = app.config['POLYSWARMD']
     session = app.config['REQUESTS_SESSION']
 
+    # Since we aren't using MAX_CONTENT_LENGTH anymore, we have to check each.
     files = [('file', (f.filename, f, 'application/octet-stream')) for f in request.files.getlist(key='file')
              if f.content_length <= g.user.max_artifact_size]
     if len(files) < len(request.files.getlist(key='file')):

--- a/src/polyswarmd/config.py
+++ b/src/polyswarmd/config.py
@@ -31,7 +31,7 @@ SUPPORTED_CONTRACT_VERSIONS = {
     'OfferRegistry': ((1, 2, 0), (1, 3, 0)),
 }
 
-FALLBACK_MAX_ARTIFACT_SIZE = 10 * 1024 * 1024
+DEFAULT_FALLBACK_SIZE = 10 * 1024 * 1024
 
 
 def is_service_reachable(session, uri):
@@ -317,7 +317,7 @@ class Config(object):
         profiler_enabled = config.get('profiler_enabled', False)
         redis_uri = config.get('redis_uri', os.environ.get('REDIS_URI', None))
         redis_client = redis.Redis.from_url(redis_uri) if redis_uri else None
-        fallback_max_artifact_size = config.get('fallback_max_artifact_size', FALLBACK_MAX_ARTIFACT_SIZE)
+        fallback_max_artifact_size = config.get('fallback_max_artifact_size', DEFAULT_FALLBACK_SIZE)
         return cls(commmunity, ipfs_uri, artifact_limit, auth_uri, require_api_key, homechain_config, sidechain_config,
                    trace_transactions, profiler_enabled, redis_client, fallback_max_artifact_size)
 
@@ -360,7 +360,7 @@ class Config(object):
         profiler_enabled = config.get('profiler_enabled', False)
         redis_uri = config.get('redis_uri', os.environ.get('REDIS_URI', None))
         redis_client = redis.Redis.from_url(redis_uri) if redis_uri else None
-        fallback_max_artifact_size = config.get('fallback_max_artifact_size', FALLBACK_MAX_ARTIFACT_SIZE)
+        fallback_max_artifact_size = config.get('fallback_max_artifact_size', DEFAULT_FALLBACK_SIZE)
 
         ret = cls(community, ipfs_uri, artifact_limit, auth_uri, require_api_key, homechain_config, sidechain_config,
                   trace_transactions, profiler_enabled, redis_client, fallback_max_artifact_size)


### PR DESCRIPTION
Removed hard coded anonymous & user sizes

Also, removes the flask MAX_CONTENT_LENGTH value, since we can't know the appropriate size going in. 

