### PR TITLE
Attempt to load metadata even if stored directly on chain

### DIFF
--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -85,11 +85,11 @@ def substitute_metadata(uri, validate=AssertionMetadata.validate, artifact_clien
         config = app.config['POLYSWARMD']
         artifact_client = config.artifact_client
 
-    content = uri
-    try:
-        if artifact_client.check_uri(uri):
-            content = artifact_client.get_artifact(uri, session=session, redis=redis).decode('utf-8')
+    if validate(json.loads(uri)):
+        return json.loads(uri)
 
+    try:
+        content = artifact_client.get_artifact(uri, session=session, redis=redis).decode('utf-8')
         if validate(json.loads(content)):
             return json.loads(content)
 
@@ -99,7 +99,7 @@ def substitute_metadata(uri, validate=AssertionMetadata.validate, artifact_clien
     except Exception:
         logger.exception(f'Error getting metadata from {artifact_client.name}')
 
-    return content
+    return uri
 
 
 @bounties.route('', methods=['POST'])

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -86,11 +86,13 @@ def substitute_metadata(uri, validate=AssertionMetadata.validate, artifact_clien
         artifact_client = config.artifact_client
 
     try:
-        content = artifact_client.get_artifact(uri, session=session, redis=redis).decode('utf-8') \
-            if artifact_client.check_uri(uri) else uri
-        loaded = json.loads(content)
-        if validate(loaded):
-            return loaded
+        if artifact_client.check_uri(uri):
+            content = json.loads(artifact_client.get_artifact(uri, session=session, redis=redis).decode('utf-8'))
+        else:
+            content = json.loads(uri)
+
+        if validate(content):
+            return content
 
     except json.JSONDecodeError:
         # Expected when people provide incorrect metadata. Not stack worthy

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -88,8 +88,9 @@ def substitute_metadata(uri, validate=AssertionMetadata.validate, artifact_clien
     try:
         content = artifact_client.get_artifact(uri, session=session, redis=redis).decode('utf-8') \
             if artifact_client.check_uri(uri) else uri
-        if validate(json.loads(content)):
-            return json.loads(content)
+        loaded = json.loads(content)
+        if validate(loaded):
+            return loaded
 
     except json.JSONDecodeError:
         # Expected when people provide incorrect metadata. Not stack worthy

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -55,36 +55,31 @@ def calculate_commitment(account, verdicts):
 
 def get_assertion(guid, index, num_artifacts):
     config = app.config['POLYSWARMD']
+    session = app.config['REQUESTS_SESSION']
     assertion = assertion_to_dict(
         g.chain.bounty_registry.contract.functions.assertionsByGuid(guid.int, index).call(),
         num_artifacts)
 
     bid = [str(b) for b in g.chain.bounty_registry.contract.functions.getBids(guid.int, index).call()]
     assertion['bid'] = bid
-    assertion['metadata'] = substitute_metadata(assertion.get('metadata', ''), redis=config.redis)
+    assertion['metadata'] = substitute_metadata(assertion.get('metadata', ''), config.artifact_client, session,
+                                                redis=config.redis)
     return assertion
 
 
 # noinspection PyBroadException
 @cache.memoize(30)
-def substitute_metadata(uri, validate=AssertionMetadata.validate, artifact_client=None, session=None, redis=None):
+def substitute_metadata(uri, artifact_client, session, validate=AssertionMetadata.validate, redis=None):
     """
     Download metadata from artifact service and validate it against the schema.
 
     :param uri: Potential artifact service uri string (or metadata string)
-    :param validate: Function that takes a loaded json blob and returns true if it matches the schema
     :param artifact_client: Artifact Client for accessing artifacts stored on a service
     :param session: Requests session for ipfs request
+    :param validate: Function that takes a loaded json blob and returns true if it matches the schema
     :param redis: Redis connection object
     :return: Metadata from artifact service, or original metadata
     """
-    if not session:
-        session = app.config['REQUESTS_SESSION']
-
-    if not artifact_client:
-        config = app.config['POLYSWARMD']
-        artifact_client = config.artifact_client
-
     try:
         if artifact_client.check_uri(uri):
             content = json.loads(artifact_client.get_artifact(uri, session=session, redis=redis).decode('utf-8'))
@@ -216,11 +211,13 @@ def get_bounty_parameters():
 @chain
 def get_bounties_guid(guid):
     config = app.config['POLYSWARMD']
+    session = app.config['REQUESTS_SESSION']
     bounty = bounty_to_dict(
         g.chain.bounty_registry.contract.functions.bountiesByGuid(guid.int).call())
     metadata = bounty.get('metadata', None)
     if metadata:
-        metadata = substitute_metadata(metadata, validate=BountyMetadata.validate, redis=config.redis)
+        metadata = substitute_metadata(metadata, config.artifact_client, session, validate=BountyMetadata.validate,
+                                       redis=config.redis)
     else:
         metadata = None
     bounty['metadata'] = metadata

--- a/src/polyswarmd/bounties.py
+++ b/src/polyswarmd/bounties.py
@@ -85,11 +85,9 @@ def substitute_metadata(uri, validate=AssertionMetadata.validate, artifact_clien
         config = app.config['POLYSWARMD']
         artifact_client = config.artifact_client
 
-    if validate(json.loads(uri)):
-        return json.loads(uri)
-
     try:
-        content = artifact_client.get_artifact(uri, session=session, redis=redis).decode('utf-8')
+        content = artifact_client.get_artifact(uri, session=session, redis=redis).decode('utf-8') \
+            if artifact_client.check_uri(uri) else uri
         if validate(json.loads(content)):
             return json.loads(content)
 

--- a/src/polyswarmd/rpc.py
+++ b/src/polyswarmd/rpc.py
@@ -123,9 +123,10 @@ class EthereumRpc:
                     }
                     metadata = bounty['data'].get('metadata', None)
                     if metadata:
-                        bounty['data']['metadata'] = substitute_metadata(metadata, validate=BountyMetadata.validate,
-                                                                         artifact_client=artifact_client,
-                                                                         session=self.session,
+                        bounty['data']['metadata'] = substitute_metadata(metadata,
+                                                                         artifact_client,
+                                                                         self.session,
+                                                                         validate=BountyMetadata.validate,
                                                                          redis=redis)
                     else:
                         bounty['data']['metadata'] = None
@@ -149,8 +150,8 @@ class EthereumRpc:
                         'txhash': event.transactionHash.hex(),
                     }
                     reveal['data']['metadata'] = substitute_metadata(reveal['data'].get('metadata', ''),
-                                                                     artifact_client=artifact_client,
-                                                                     session=self.session,
+                                                                     artifact_client,
+                                                                     self.session,
                                                                      redis=redis)
 
                     self.broadcast(reveal)


### PR DESCRIPTION
Fixes the issue where some engines metadata is a json string instead of decoded json. 