### PR TITLE
Use threadpool executor on rlp decode

### DIFF
--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -31,7 +31,7 @@ session.request = functools.partial(session.request, timeout=10)
 
 app.config['REQUESTS_SESSION'] = session
 app.config['CHECK_BLOCK_LIMIT'] = True
-app.config['GEVENT_THREADPOOL'] = ThreadPoolExecutor()
+app.config['GEVENT_THREADPOOL'] = ThreadPoolExecutor(None)
 
 
 install_error_handlers(app)

--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -1,4 +1,3 @@
-from concurrent.futures import ThreadPoolExecutor
 from requests_futures.sessions import FuturesSession
 from polyswarmd.monkey import patch_all
 
@@ -10,6 +9,7 @@ import functools
 
 from flask import Flask, g, request
 from flask_caching import Cache
+from gevent.threadpool import ThreadPoolExecutor
 
 from polyswarmd.config import Config, is_service_reachable, DEFAULT_FALLBACK_SIZE
 from polyswarmd.logger import init_logging
@@ -31,6 +31,7 @@ session.request = functools.partial(session.request, timeout=10)
 
 app.config['REQUESTS_SESSION'] = session
 app.config['CHECK_BLOCK_LIMIT'] = True
+app.config['GEVENT_THREADPOOL'] = ThreadPoolExecutor(4)
 
 
 install_error_handlers(app)

--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -1,15 +1,15 @@
+from concurrent.futures import ThreadPoolExecutor
 from requests_futures.sessions import FuturesSession
 from polyswarmd.monkey import patch_all
 
 patch_all()
 
 import datetime
-import logging
 import functools
+import logging
 
 from flask import Flask, g, request
 from flask_caching import Cache
-from gevent.threadpool import ThreadPoolExecutor
 
 from polyswarmd.config import Config, is_service_reachable, DEFAULT_FALLBACK_SIZE
 from polyswarmd.logger import init_logging
@@ -31,7 +31,7 @@ session.request = functools.partial(session.request, timeout=10)
 
 app.config['REQUESTS_SESSION'] = session
 app.config['CHECK_BLOCK_LIMIT'] = True
-app.config['GEVENT_THREADPOOL'] = ThreadPoolExecutor(None)
+app.config['THREADPOOL'] = ThreadPoolExecutor()
 
 
 install_error_handlers(app)

--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -31,7 +31,7 @@ session.request = functools.partial(session.request, timeout=10)
 
 app.config['REQUESTS_SESSION'] = session
 app.config['CHECK_BLOCK_LIMIT'] = True
-app.config['GEVENT_THREADPOOL'] = ThreadPoolExecutor(4)
+app.config['GEVENT_THREADPOOL'] = ThreadPoolExecutor()
 
 
 install_error_handlers(app)

--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -137,7 +137,7 @@ def get_transactions():
 @misc.route('/transactions', methods=['POST'])
 @chain
 def post_transactions():
-    threadpool_executor = app.config['GEVENT_THREADPOOL']
+    threadpool_executor = app.config['THREADPOOL']
     account = g.chain.w3.toChecksumAddress(g.eth_address)
 
     # Does not include offer_multisig contracts, need to loosen validation for those

--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -137,6 +137,7 @@ def get_transactions():
 @misc.route('/transactions', methods=['POST'])
 @chain
 def post_transactions():
+    threadpool_executor = app.config['GEVENT_THREADPOOL']
     account = g.chain.w3.toChecksumAddress(g.eth_address)
 
     # Does not include offer_multisig contracts, need to loosen validation for those
@@ -174,16 +175,16 @@ def post_transactions():
 
     errors = False
     results = []
-    for raw_tx in body['transactions']:
-        try:
-            tx = rlp.decode(bytes.fromhex(raw_tx), ConstantinopleTransaction)
-        except ValueError as e:
-            logger.error('Invalid transaction: %s', e)
-            continue
-        except Exception:
-            logger.exception('Unexpected exception while parsing transaction')
-            continue
+    try:
+        future = threadpool_executor.submit(decode_all, body['transactions'])
+        decoded_txs = future.result()
+    except ValueError as e:
+        return failure(f'Invalid transaction: {e}', 400)
+    except Exception:
+        logger.exception('Unexpected exception while parsing transaction')
+        return failure('Unexpected exception while parsing transaction', 500)
 
+    for raw_tx, tx in zip(body['transactions'], decoded_txs):
         if withdrawal_only and not is_withdrawal(tx):
             errors = True
             results.append({
@@ -267,6 +268,10 @@ def build_transaction(call, nonce):
     logger.debug('options: %s', options)
 
     return call.buildTransaction(options)
+
+
+def decode_all(raw_txs):
+    return [rlp.decode(bytes.fromhex(raw_tx), sedes=ConstantinopleTransaction) for raw_tx in raw_txs]
 
 
 def is_withdrawal(tx):


### PR DESCRIPTION
rlp decode is blocking, and caused the `/status` route to fail, and created backups in transactions. 

Use gevent threadpool we can continue to respond to other requests while decoding transactions to verify them