### PR TITLE
Disable websocket via env var

### DIFF
--- a/src/polyswarmd/__init__.py
+++ b/src/polyswarmd/__init__.py
@@ -1,3 +1,4 @@
+import os
 from concurrent.futures import ThreadPoolExecutor
 from requests_futures.sessions import FuturesSession
 from polyswarmd.monkey import patch_all
@@ -54,7 +55,9 @@ app.register_blueprint(relay, url_prefix='/relay')
 app.register_blueprint(offers, url_prefix='/offers')
 app.register_blueprint(staking, url_prefix='/staking')
 
-init_websockets(app)
+if not os.getenv('DISABLE_WEBSOCKETS', False):
+    init_websockets(app)
+
 setup_profiler(app)
 cache.init_app(app)
 


### PR DESCRIPTION
This adds an environment variable `DISABLE_WEBSOCKETS` to disable websocket support. EthereumRpc filters are installed the first time that a request is made to the websocket endpoint, but since that endpoint will not be initialized, we don't need to disable any of that code path.