### PR TITLE
Switch to compiled fastjsonschemas

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,5 +3,4 @@ isort==4.3.21
 mypy-extensions==0.4.3
 mypy==0.740
 pytest==4.0.0
-tox==3.14.1
 yapf==0.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 base58==1.0.3
 click==7.0
+fastjsonschema==2.14.1
 Flask-Caching==1.7.2
 Flask-Sockets==0.2.1
 Flask==1.0.2
@@ -7,7 +8,6 @@ gevent-websocket==0.10.1
 gevent==1.4.0
 gunicorn==19.9.0
 ipfshttpclient==0.4.12
-jsonschema==3.2.0
 polyswarm-artifact==1.2.1
 psycopg2-binary==2.8.4
 pytest==4.0.0

--- a/src/polyswarmd/eth.py
+++ b/src/polyswarmd/eth.py
@@ -433,9 +433,10 @@ def events_from_transaction(txhash, chain):
                 logger.warning("No contract event for: %s", filter_event)
                 continue
             # Now pull out the pertinent logs from the transaction receipt
+            abi = contract_event._get_event_abi()
             for log in receipt['logs']:
                 try:
-                    event_log = get_event_data(contract_event._get_event_abi(), log)
+                    event_log = get_event_data(abi, log)
                     if event_log:
                         ret[key] = [extractor.extract(event_log['args'])]
                     break

--- a/src/polyswarmd/offers.py
+++ b/src/polyswarmd/offers.py
@@ -1,9 +1,8 @@
 import logging
 import uuid
 
+import fastjsonschema
 from flask import Blueprint, g, request
-import jsonschema
-from jsonschema.exceptions import ValidationError
 
 from polyswarmd.chains import chain
 from polyswarmd.eth import build_transaction
@@ -20,6 +19,25 @@ from polyswarmd.utils import (
 logger = logging.getLogger(__name__)
 offers = Blueprint('offers', __name__)
 
+_post_create_offer_channel_schema = fastjsonschema.compile({
+    'type': 'object',
+    'properties': {
+        'ambassador': {
+            'type': 'string',
+            'minLength': 42,
+        },
+        'expert': {
+            'type': 'string',
+            'minLength': 42,
+        },
+        'settlementPeriodLength': {
+            'type': 'integer',
+            'minimum': 0,
+        },
+    },
+    'required': ['ambassador', 'expert', 'settlementPeriodLength'],
+})
+
 
 @offers.route('', methods=['POST'])
 @chain(chain_name='home')
@@ -29,28 +47,9 @@ def post_create_offer_channel():
 
     body = request.get_json()
 
-    schema = {
-        'type': 'object',
-        'properties': {
-            'ambassador': {
-                'type': 'string',
-                'minLength': 42,
-            },
-            'expert': {
-                'type': 'string',
-                'minLength': 42,
-            },
-            'settlementPeriodLength': {
-                'type': 'integer',
-                'minimum': 0,
-            },
-        },
-        'required': ['ambassador', 'expert', 'settlementPeriodLength'],
-    }
-
     try:
-        jsonschema.validate(body, schema)
-    except ValidationError as e:
+        _post_create_offer_channel_schema(body)
+    except fastjsonschema.JsonSchemaException as e:
         return failure('Invalid JSON: ' + e.message)
 
     guid = uuid.uuid4()
@@ -69,6 +68,19 @@ def post_create_offer_channel():
     return success({'transactions': transactions})
 
 
+_post_uri_schema = fastjsonschema.compile({
+    'type': 'object',
+    'properties': {
+        'websocketUri': {
+            'type': 'string',
+            'minLength': 1,
+            'maxLength': 32
+        }
+    },
+    'required': ['websocketUri'],
+})
+
+
 @offers.route('/<uuid:guid>/uri', methods=['POST'])
 @chain(chain_name='home')
 def post_uri(guid):
@@ -82,21 +94,9 @@ def post_uri(guid):
 
     body = request.get_json()
 
-    schema = {
-        'type': 'object',
-        'properties': {
-            'websocketUri': {
-                'type': 'string',
-                'minLength': 1,
-                'maxLength': 32
-            }
-        },
-        'required': ['websocketUri'],
-    }
-
     try:
-        jsonschema.validate(body, schema)
-    except ValidationError as e:
+        _post_uri_schema(body)
+    except fastjsonschema.JsonSchemaException as e:
         return failure('Invalid JSON: ' + e.message)
 
     websocket_uri = body['websocketUri']
@@ -109,6 +109,30 @@ def post_uri(guid):
     ]
 
     return success({'transactions': transactions})
+
+
+_post_open_schema = fastjsonschema.compile({
+    'type': 'object',
+    'properties': {
+        'state': {
+            'type': 'string',
+            'minLength': 32,
+        },
+        'r': {
+            'type': 'string',
+            'minLength': 64,
+        },
+        'v': {
+            'type': 'integer',
+            'minimum': 0,
+        },
+        's': {
+            'type': 'string',
+            'minLength': 64
+        },
+    },
+    'required': ['state', 'r', 'v', 's'],
+})
 
 
 @offers.route('/<uuid:guid>/open', methods=['POST'])
@@ -124,32 +148,9 @@ def post_open(guid):
 
     body = request.get_json()
 
-    schema = {
-        'type': 'object',
-        'properties': {
-            'state': {
-                'type': 'string',
-                'minLength': 32,
-            },
-            'r': {
-                'type': 'string',
-                'minLength': 64,
-            },
-            'v': {
-                'type': 'integer',
-                'minimum': 0,
-            },
-            's': {
-                'type': 'string',
-                'minLength': 64
-            },
-        },
-        'required': ['state', 'r', 'v', 's'],
-    }
-
     try:
-        jsonschema.validate(body, schema)
-    except ValidationError as e:
+        _post_open_schema(body)
+    except fastjsonschema.JsonSchemaException as e:
         return failure('Invalid JSON: ' + e.message)
 
     state = body['state']
@@ -192,6 +193,30 @@ def post_cancel(guid):
     return success({'transactions': transactions})
 
 
+_post_join_schema = fastjsonschema.compile({
+    'type': 'object',
+    'properties': {
+        'state': {
+            'type': 'string',
+            'minLength': 32,
+        },
+        'r': {
+            'type': 'string',
+            'minLength': 64,
+        },
+        'v': {
+            'type': 'integer',
+            'minimum': 0,
+        },
+        's': {
+            'type': 'string',
+            'minLength': 64
+        },
+    },
+    'required': ['state', 'r', 'v', 's'],
+})
+
+
 @offers.route('/<uuid:guid>/join', methods=['POST'])
 @chain(chain_name='home')
 def post_join(guid):
@@ -205,32 +230,9 @@ def post_join(guid):
 
     body = request.get_json()
 
-    schema = {
-        'type': 'object',
-        'properties': {
-            'state': {
-                'type': 'string',
-                'minLength': 32,
-            },
-            'r': {
-                'type': 'string',
-                'minLength': 64,
-            },
-            'v': {
-                'type': 'integer',
-                'minimum': 0,
-            },
-            's': {
-                'type': 'string',
-                'minLength': 64
-            },
-        },
-        'required': ['state', 'r', 'v', 's'],
-    }
-
     try:
-        jsonschema.validate(body, schema)
-    except ValidationError as e:
+        _post_join_schema(body)
+    except fastjsonschema.JsonSchemaException as e:
         return failure('Invalid JSON: ' + e.message)
 
     state = body['state']
@@ -248,6 +250,33 @@ def post_join(guid):
     return success({'transactions': transactions})
 
 
+_post_close_schema = fastjsonschema.compile({
+    'type': 'object',
+    'properties': {
+        'state': {
+            'type': 'string',
+            'minLength': 32,
+        },
+        'r': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+        'v': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+        's': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+    },
+    'required': ['state', 'r', 'v', 's'],
+})
+
+
 @offers.route('/<uuid:guid>/close', methods=['POST'])
 @chain(chain_name='home')
 def post_close(guid):
@@ -261,35 +290,9 @@ def post_close(guid):
 
     body = request.get_json()
 
-    schema = {
-        'type': 'object',
-        'properties': {
-            'state': {
-                'type': 'string',
-                'minLength': 32,
-            },
-            'r': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-            'v': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-            's': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-        },
-        'required': ['state', 'r', 'v', 's'],
-    }
-
     try:
-        jsonschema.validate(body, schema)
-    except ValidationError as e:
+        _post_close_schema(body)
+    except fastjsonschema.JsonSchemaException as e:
         return failure('Invalid JSON: ' + e.message)
 
     state = g.chain.w3.toBytes(hexstr=body['state'])
@@ -302,6 +305,33 @@ def post_close(guid):
     ]
 
     return success({'transactions': transactions})
+
+
+_post_close_challenged_schema = fastjsonschema.compile({
+    'type': 'object',
+    'properties': {
+        'state': {
+            'type': 'string',
+            'minLength': 32,
+        },
+        'r': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+        'v': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+        's': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+    },
+    'required': ['state', 'r', 'v', 's'],
+})
 
 
 # for closing a challenged state with a timeout
@@ -318,35 +348,9 @@ def post_close_challenged(guid):
 
     body = request.get_json()
 
-    schema = {
-        'type': 'object',
-        'properties': {
-            'state': {
-                'type': 'string',
-                'minLength': 32,
-            },
-            'r': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-            'v': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-            's': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-        },
-        'required': ['state', 'r', 'v', 's'],
-    }
-
     try:
-        jsonschema.validate(body, schema)
-    except ValidationError as e:
+        _post_close_challenged_schema(body)
+    except fastjsonschema.JsonSchemaException as e:
         return failure('Invalid JSON: ' + e.message)
 
     state = g.chain.w3.toBytes(hexstr=body['state'])
@@ -363,6 +367,33 @@ def post_close_challenged(guid):
     return success({'transactions': transactions})
 
 
+_post_settle_schema = fastjsonschema.compile({
+    'type': 'object',
+    'properties': {
+        'state': {
+            'type': 'string',
+            'minLength': 32,
+        },
+        'r': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+        'v': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+        's': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+    },
+    'required': ['state', 'r', 'v', 's'],
+})
+
+
 @offers.route('/<uuid:guid>/settle', methods=['POST'])
 @chain(chain_name='home')
 def post_settle(guid):
@@ -376,35 +407,9 @@ def post_settle(guid):
 
     body = request.get_json()
 
-    schema = {
-        'type': 'object',
-        'properties': {
-            'state': {
-                'type': 'string',
-                'minLength': 32,
-            },
-            'r': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-            'v': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-            's': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-        },
-        'required': ['state', 'r', 'v', 's'],
-    }
-
     try:
-        jsonschema.validate(body, schema)
-    except ValidationError as e:
+        _post_settle_schema(body)
+    except fastjsonschema.JsonSchemaException as e:
         return failure('Invalid JSON: ' + e.message)
 
     state = g.chain.w3.toBytes(hexstr=body['state'])
@@ -419,101 +424,102 @@ def post_settle(guid):
     return success({'transactions': transactions})
 
 
+_create_state_schema = fastjsonschema.compile({
+    'type':
+        'object',
+    'properties': {
+        'close_flag': {
+            'type': 'integer',
+            'minimum': 0,
+            'maximum': 1
+        },
+        'nonce': {
+            'type': 'integer',
+            'minimum': 0,
+        },
+        'ambassador': {
+            'type': 'string',
+            'minLength': 1,
+        },
+        'expert': {
+            'type': 'string',
+            'minLength': 1,
+        },
+        'msig_address': {
+            'type': 'string',
+            'minLength': 1,
+        },
+        'ambassador_balance': {
+            'type': 'integer',
+            'minimum': 0,
+        },
+        'expert_balance': {
+            'type': 'integer',
+            'minimum': 0,
+        },
+        'guid': {
+            'type': 'string',
+            'minLength': 1,
+        },
+        'offer_amount': {
+            'type': 'integer',
+            'minimum': 0,
+        },
+        'artifact_hash': {
+            'type': 'string',
+            'minimum': 0,
+        },
+        'ipfs_hash': {
+            'type': 'string',
+            'minimum': 0,
+        },
+        'engagement_deadline': {
+            'type': 'string',
+            'minimum': 0,
+        },
+        'assertion_deadline': {
+            'type': 'string',
+            'minLength': 1
+        },
+        'mask': {
+            'type': 'array',
+            'maxItems': 256,
+            'items': {
+                'type': 'boolean',
+            },
+        },
+        'verdicts': {
+            'type': 'array',
+            'maxItems': 256,
+            'items': {
+                'type': 'boolean',
+            },
+        },
+        'meta_data': {
+            'type': 'string',
+            'minLength': 1
+        }
+    },
+    # If either 'mask' or 'verdicts' are present, both must be.
+    'dependencies': {
+        'mask': ['verdicts'],
+        'verdicts': ['mask']
+    },
+    'required': [
+        'close_flag', 'nonce', 'ambassador', 'expert', 'msig_address', 'ambassador_balance',
+        'expert_balance', 'guid', 'offer_amount'
+    ],
+})
+
+
 @offers.route('/state', methods=['POST'])
 @chain(chain_name='home')
 def create_state():
     body = request.get_json()
 
-    schema = {
-        'type':
-            'object',
-        'properties': {
-            'close_flag': {
-                'type': 'integer',
-                'minimum': 0,
-                'maximum': 1
-            },
-            'nonce': {
-                'type': 'integer',
-                'minimum': 0,
-            },
-            'ambassador': {
-                'type': 'string',
-                'minLength': 1,
-            },
-            'expert': {
-                'type': 'string',
-                'minLength': 1,
-            },
-            'msig_address': {
-                'type': 'string',
-                'minLength': 1,
-            },
-            'ambassador_balance': {
-                'type': 'integer',
-                'minimum': 0,
-            },
-            'expert_balance': {
-                'type': 'integer',
-                'minimum': 0,
-            },
-            'guid': {
-                'type': 'string',
-                'minLength': 1,
-            },
-            'offer_amount': {
-                'type': 'integer',
-                'minimum': 0,
-            },
-            'artifact_hash': {
-                'type': 'string',
-                'minimum': 0,
-            },
-            'ipfs_hash': {
-                'type': 'string',
-                'minimum': 0,
-            },
-            'engagement_deadline': {
-                'type': 'string',
-                'minimum': 0,
-            },
-            'assertion_deadline': {
-                'type': 'string',
-                'minLength': 1
-            },
-            'mask': {
-                'type': 'array',
-                'maxItems': 256,
-                'items': {
-                    'type': 'boolean',
-                },
-            },
-            'verdicts': {
-                'type': 'array',
-                'maxItems': 256,
-                'items': {
-                    'type': 'boolean',
-                },
-            },
-            'meta_data': {
-                'type': 'string',
-                'minLength': 1
-            }
-        },
-        # If either 'mask' or 'verdicts' are present, both must be.
-        'dependencies': {
-            'mask': ['verdicts'],
-            'verdicts': ['mask']
-        },
-        'required': [
-            'close_flag', 'nonce', 'ambassador', 'expert', 'msig_address', 'ambassador_balance',
-            'expert_balance', 'guid', 'offer_amount'
-        ],
-    }
-
     try:
-        jsonschema.validate(body, schema)
-    except ValidationError as e:
+        _create_state_schema(body)
+    except fastjsonschema.JsonSchemaException as e:
         return failure('Invalid JSON: ' + e.message)
 
     body['token_address'] = str(g.chain.nectar_token.address)
@@ -523,6 +529,33 @@ def create_state():
         body['mask'] = bool_list_to_int(body['mask'])
 
     return success({'state': dict_to_state(body)})
+
+
+_post_challange_schema = fastjsonschema.compile({
+    'type': 'object',
+    'properties': {
+        'state': {
+            'type': 'string',
+            'minLength': 32,
+        },
+        'r': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+        'v': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+        's': {
+            'type': 'array',
+            'minLength': 2,
+            'maxLength': 2,
+        },
+    },
+    'required': ['state', 'r', 'v', 's'],
+})
 
 
 @offers.route('/<uuid:guid>/challenge', methods=['POST'])
@@ -538,35 +571,9 @@ def post_challange(guid):
 
     body = request.get_json()
 
-    schema = {
-        'type': 'object',
-        'properties': {
-            'state': {
-                'type': 'string',
-                'minLength': 32,
-            },
-            'r': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-            'v': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-            's': {
-                'type': 'array',
-                'minLength': 2,
-                'maxLength': 2,
-            },
-        },
-        'required': ['state', 'r', 'v', 's'],
-    }
-
     try:
-        jsonschema.validate(body, schema)
-    except ValidationError as e:
+        _post_challange_schema(body)
+    except fastjsonschema.JsonSchemaException as e:
         return failure('Invalid JSON: ' + e.message)
 
     state = g.chain.w3.toBytes(hexstr=body['state'])

--- a/src/polyswarmd/rpc.py
+++ b/src/polyswarmd/rpc.py
@@ -25,6 +25,7 @@ class EthereumRpc:
         Send a message to all connected WebSockets
         :param message: dict to be converted to json and sent
         """
+        # XXX This can be replaced with a broadcast inside the WebsocketHandlerApplication
         with self.websockets_lock:
             for ws in self.websockets:
                 ws.send(message)

--- a/src/polyswarmd/websockets/messages.py
+++ b/src/polyswarmd/websockets/messages.py
@@ -367,7 +367,7 @@ class NewBounty(WebsocketFilterMessage[NewBountyMessageData]):
             'guid': guid,
             'artifact_type': {
                 'type': 'string',
-                'enum': ['file', 'url'],
+                'enum': [name.lower() for name, value in ArtifactType.__members__.items()],
                 'srckey': lambda k, e: ArtifactType.to_string(ArtifactType(e['artifactType']))
             },
             'author': ethereum_address,

--- a/src/polyswarmd/websockets/messages.py
+++ b/src/polyswarmd/websockets/messages.py
@@ -206,11 +206,7 @@ class NewWithdrawal(EventLogMessage[NewWithdrawalMessageData]):
 
     doctest:
 
-    >>> args = {
-    ... 'to': "0x00000000000000000000000000000001",
-    ... 'from': "0x00000000000000000000000000000002",
-    ... 'value': 1 }
-    >>> NewWithdrawal.extract(args)
+    >>> NewWithdrawal.extract({'to': addr1, 'from': addr2, 'value': 1 })
     {'to': '0x00000000000000000000000000000001', 'value': 1}
     >>> NewWithdrawal.contract_event_name
     'NewWithdrawal'
@@ -493,8 +489,7 @@ class NewVote(WebsocketFilterMessage[NewVoteMessageData]):
     ... 'voter': '0xDF9246BB76DF876Cef8bf8af8493074755feb58c',
     ... 'votes': 128,
     ... 'numArtifacts': 4 })
-    >>> new_vote = NewVote.serialize_message(event)
-    >>> decoded_msg(new_vote)
+    >>> decoded_msg(NewVote.serialize_message(event))
     {'block_number': 117,
      'data': {'bounty_guid': '00000000-0000-0000-0000-000000000002',
               'voter': '0xDF9246BB76DF876Cef8bf8af8493074755feb58c',
@@ -513,11 +508,39 @@ class NewVote(WebsocketFilterMessage[NewVoteMessageData]):
 
 
 class QuorumReached(WebsocketFilterMessage[QuorumReachedMessageData]):
+    """QuorumReached
+
+    doctest:
+
+    >>> event = mkevent({'bountyGuid': 16577})
+    >>> decoded_msg(QuorumReached.serialize_message(event))
+    {'block_number': 117,
+     'data': {'bounty_guid': '00000000-0000-0000-0000-0000000040c1'},
+     'event': 'quorum',
+     'txhash': '0000000000000000000000000000000b'}
+    """
     event: ClassVar[str] = 'quorum'
     schema: ClassVar[PSJSONSchema] = PSJSONSchema({'properties': {'bounty_guid': bounty_guid}})
 
 
 class SettledBounty(WebsocketFilterMessage[SettledBountyMessageData]):
+    """SettledBounty
+
+    doctest:
+
+    >>> event = mkevent({
+    ... 'bountyGuid': 16577,
+    ... 'settler': addr1,
+    ... 'payout': 1000 })
+    >>> decoded_msg(SettledBounty.serialize_message(event))
+    {'block_number': 117,
+     'data': {'bounty_guid': '00000000-0000-0000-0000-0000000040c1',
+              'payout': 1000,
+              'settler': '0x00000000000000000000000000000001'},
+     'event': 'settled_bounty',
+     'txhash': '0000000000000000000000000000000b'}
+
+    """
     event: ClassVar[str] = 'settled_bounty'
     schema: ClassVar[PSJSONSchema] = PSJSONSchema({
         'properties': {
@@ -536,8 +559,7 @@ class InitializedChannel(WebsocketFilterMessage[InitializedChannelMessageData]):
     ... 'expert': '0xDF9246BB76DF876Cef8bf8af8493074755feb58c',
     ... 'guid': 1,
     ... 'msig': '0x789246BB76D18C6C7f8bd8ac8423478795f71bf9' })
-    >>> msg = InitializedChannel.serialize_message(event)
-    >>> decoded_msg(msg)
+    >>> decoded_msg(InitializedChannel.serialize_message(event))
     {'block_number': 117,
      'data': {'ambassador': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
               'expert': '0xDF9246BB76DF876Cef8bf8af8493074755feb58c',
@@ -590,6 +612,23 @@ class ClosedAgreement(WebsocketFilterMessage[ClosedAgreementMessageData]):
 
 
 class StartedSettle(WebsocketFilterMessage[StartedSettleMessageData]):
+    """StartedSettle
+
+    doctest:
+
+    >>> event = mkevent({
+    ... 'initiator': addr1,
+    ... 'sequence': 1688,
+    ... 'settlementPeriodEnd': 229 })
+    >>> decoded_msg(StartedSettle.serialize_message(event))
+    {'block_number': 117,
+     'data': {'initiator': '0x00000000000000000000000000000001',
+              'nonce': 1688,
+              'settle_period_end': 229},
+     'event': 'settle_started',
+     'txhash': '0000000000000000000000000000000b'}
+
+    """
     event: ClassVar[str] = 'settle_started'
     schema: ClassVar[PSJSONSchema] = PSJSONSchema({
         'properties': {
@@ -607,6 +646,22 @@ class StartedSettle(WebsocketFilterMessage[StartedSettleMessageData]):
 
 
 class SettleStateChallenged(WebsocketFilterMessage[SettleStateChallengedMessageData]):
+    """SettleStateChallenged
+
+    doctest:
+
+    >>> event = mkevent({
+    ... 'challenger': addr1,
+    ... 'sequence': 1688,
+    ... 'settlementPeriodEnd': 229 })
+    >>> decoded_msg(SettleStateChallenged.serialize_message(event))
+    {'block_number': 117,
+     'data': {'challenger': '0x00000000000000000000000000000001',
+              'nonce': 1688,
+              'settle_period_end': 229},
+     'event': 'settle_challenged',
+     'txhash': '0000000000000000000000000000000b'}
+    """
     event: ClassVar[str] = 'settle_challenged'
     schema: ClassVar[PSJSONSchema] = PSJSONSchema({
         'properties': {
@@ -628,13 +683,10 @@ class Deprecated(WebsocketFilterMessage[None]):
 
     doctest:
 
-    >>> LatestEvent.make(chain1)
-    <class 'websockets.messages.LatestEvent'>
     >>> event = mkevent({'a': 1, 'hello': 'world', 'should_not_be_here': True})
     >>> Deprecated.contract_event_name
     'Deprecated'
-    >>> msg = Deprecated.serialize_message(event)
-    >>> decoded_msg(msg)
+    >>> decoded_msg(Deprecated.serialize_message(event))
     {'block_number': 117,
      'data': {},
      'event': 'deprecated',
@@ -664,8 +716,7 @@ class LatestEvent(WebsocketFilterMessage[LatestEventMessageData]):
     >>> event = mkevent({'a': 1, 'hello': 'world', 'should_not_be_here': True})
     >>> LatestEvent.contract_event_name
     'latest'
-    >>> msg = LatestEvent.serialize_message(event)
-    >>> decoded_msg(msg)
+    >>> decoded_msg(LatestEvent.serialize_message(event))
     {'data': {'number': 117}, 'event': 'block'}
     """
     event: ClassVar[str] = 'block'


### PR DESCRIPTION
@supernothing pointed out in an earlier PR how slow `jsonschema` could really be
(see: https://www.peterbe.com/plog/jsonschema-validate-10x-faster-in-python) and proposed a future change.

This commit is a crude first attempt to do just that by running an editor macro over the codebase to replace our existing `jsonschema` validators with new, much faster, compiled `fastjsonschema` validators.

This PR also includes a change in `eth.py` (line 432) that replaces `processReceipt`, but only processes one log at a time, instead of a whole transaction receipt.