### PR TITLE
Last-minute improvements to unit-test infrastructure & privately-discussed changes

### DIFF
--- a/src/polyswarmd/config/contract.py
+++ b/src/polyswarmd/config/contract.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import time
-from typing import Any, Callable, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from consul import Timeout
 from web3 import HTTPProvider, Web3

--- a/src/polyswarmd/config/polyswarmd.py
+++ b/src/polyswarmd/config/polyswarmd.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 import os
 import sys
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 from urllib.parse import urlparse
 
 from consul import Consul as ConsulClient

--- a/src/polyswarmd/services/artifact/__init__.py
+++ b/src/polyswarmd/services/artifact/__init__.py
@@ -1,2 +1,4 @@
 from .client import AbstractArtifactServiceClient
 from .service import ArtifactServices
+
+__all__ = ['AbstractArtifactServiceClient', 'ArtifactServices']

--- a/src/polyswarmd/services/ethereum/__init__.py
+++ b/src/polyswarmd/services/ethereum/__init__.py
@@ -1,1 +1,3 @@
 from .service import EthereumService
+
+__all__ = ['EthereumService']

--- a/src/polyswarmd/utils/__init__.py
+++ b/src/polyswarmd/utils/__init__.py
@@ -1,1 +1,35 @@
-from .utils import *
+from .utils import (
+    IN_TESTENV,
+    assertion_to_dict,
+    bloom_to_dict,
+    bool_list_to_int,
+    bounty_to_dict,
+    cache_contract_view,
+    camel_case_to_snake_case,
+    channel_to_dict,
+    dict_to_state,
+    g,
+    int_to_bool_list,
+    logging,
+    new_cancel_agreement_event_to_dict,
+    new_init_channel_event_to_dict,
+    new_settle_challenged_event,
+    new_settle_started_event,
+    safe_int_to_bool_list,
+    sha3,
+    state_to_dict,
+    to_padded_hex,
+    uint256_list_to_hex_string,
+    uuid,
+    validate_ws_url,
+    vote_to_dict,
+)
+
+__all__ = [
+    'uuid', 'logging', 'IN_TESTENV', 'assertion_to_dict', 'bloom_to_dict', 'bool_list_to_int',
+    'bounty_to_dict', 'cache_contract_view', 'camel_case_to_snake_case', 'channel_to_dict', 'g',
+    'dict_to_state', 'int_to_bool_list', 'new_cancel_agreement_event_to_dict',
+    'new_init_channel_event_to_dict', 'new_settle_challenged_event', 'new_settle_started_event',
+    'safe_int_to_bool_list', 'state_to_dict', 'to_padded_hex', 'sha3', 'uint256_list_to_hex_string',
+    'validate_ws_url', 'vote_to_dict'
+]

--- a/src/polyswarmd/utils/utils.py
+++ b/src/polyswarmd/utils/utils.py
@@ -259,15 +259,20 @@ def cache_contract_view(
     """Returns tuple with boolean to indicate chached, and the response from chain, or from redis cache
 
     >>> from collections import namedtuple
-    >>> cache_contract_view(namedtuple('ContractCall', 'call')(lambda : '12'), '', None)
+    >>> ContractCall = namedtuple('ContractCall', 'call')
+    >>> cache_contract_view(ContractCall(lambda : '12'), '', None)
     (False, '12')
-    >>> cache_contract_view(namedtuple('ContractCall', 'call')(lambda : '12'), '', redis=namedtuple('Redis', ('get', 'exists'))(lambda k: '13', lambda k: True))
+    >>> Redis = namedtuple('Redis', ('get', 'set', 'exists'))
+    >>> cache_contract_view(ContractCall(lambda : '12'), '', redis=Redis(lambda k: '13', None, lambda k: True))
     (True, '13')
-    >>> cache_contract_view(namedtuple('ContractCall', 'call')(lambda : '12'), '', redis=namedtuple('Redis', ('get', 'set', 'exists'))(lambda k: '13', lambda k, v, ex: None, lambda k: False))
+    >>> cache_contract_view(ContractCall(lambda : '12'), '',
+    ... redis=Redis(lambda k: '13', lambda k, v, ex: None, lambda k: False))
     (False, '12')
-    >>> cache_contract_view(namedtuple('ContractCall', 'call')(lambda : '12'), '', redis=namedtuple('Redis', ('get', 'set', 'exists'))(lambda k: '13', lambda k, v, ex: None, lambda k: True), invalidate=True)
+    >>> cache_contract_view(ContractCall(lambda : '12'), '',
+    ... redis=Redis(lambda k: '13', lambda k, v, ex: None, lambda k: True), invalidate=True)
     (False, '12')
-    >>> cache_contract_view(namedtuple('ContractCall', 'call')(lambda : '12'), '', redis=namedtuple('Redis', ('get', 'set', 'exists'))(lambda k: '13', lambda k, v, ex: None, lambda k: True), invalidate=False)
+    >>> cache_contract_view(ContractCall(lambda : '12'), '', redis=
+    ... Redis(lambda k: '13', lambda k, v, ex: None, lambda k: True), invalidate=False)
     (True, '13')
     """
     if redis is None:

--- a/src/polyswarmd/views/artifacts.py
+++ b/src/polyswarmd/views/artifacts.py
@@ -93,7 +93,7 @@ def post_artifacts():
     except (AttributeError, IOError):
         logger.error('Error checking file size')
         return failure('Unable to read file sizes', 400)
-    except ArtifactTooLargeException as e:
+    except ArtifactTooLargeException:
         return failure('Artifact too large', 413)
     except ArtifactEmptyException:
         return failure('Artifact empty', 400)

--- a/src/polyswarmd/websockets/conftest.py
+++ b/src/polyswarmd/websockets/conftest.py
@@ -1,9 +1,11 @@
-import pytest
-import json
 from collections import namedtuple
+import json
 from pprint import pprint
-from polyswarmd.websockets import messages, filter
+
+import pytest
 import ujson
+
+from polyswarmd.websockets import messages
 
 
 @pytest.fixture(autouse=True)

--- a/src/polyswarmd/websockets/conftest.py
+++ b/src/polyswarmd/websockets/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import json
 from collections import namedtuple
 from pprint import pprint
-from . import messages, filter
+from polyswarmd.websockets import messages, filter
 import ujson
 
 

--- a/src/polyswarmd/websockets/conftest.py
+++ b/src/polyswarmd/websockets/conftest.py
@@ -55,24 +55,32 @@ def mock_md_fetch(monkeypatch):
     monkeypatch.setattr(messages.MetadataHandler, "_substitute_metadata", mock_sub)
 
 
-BBLOCK = 117
-_EVTDEFAULT = {
-    'args': {},
-    'event': 'test event',
-    'logIndex': 19845,
-    'transactionIndex': 1276,
-    'transactionHash': (11).to_bytes(16, byteorder='big'),
-    'address': '0xFACE0EEE000000000000000000000001',
-    'blockHash': (90909090).to_bytes(16, byteorder='big'),
-    'blockNumber': BBLOCK,
-}
+class mkevent:
+    DEFAULT_BLOCK = 117
+    ALTERNATE_BLOCK = 220
 
+    def __init__(self, *args, **kwargs):
+        event_default = {
+            'args': {},
+            'event': 'test event',
+            'logIndex': 19845,
+            'transactionIndex': 1276,
+            'transactionHash': (11).to_bytes(16, byteorder='big'),
+            'address': '0xFACE0EEE000000000000000000000001',
+            'blockHash': (90909090).to_bytes(16, byteorder='big'),
+            'blockNumber': self.DEFAULT_BLOCK,
+        }
+        for i, (attr, default) in enumerate(event_default.items()):
+            if len(args) > i:
+                setattr(self, attr, args[i])
+            elif attr in kwargs:
+                setattr(self, attr, kwargs[attr])
+            else:
+                setattr(self, attr, default)
 
-class mkevent(namedtuple('mkevent', _EVTDEFAULT.keys(), defaults=_EVTDEFAULT.values())):  # type: ignore
     def __getitem__(self, k):
         if (type(k) == str):
             return self.__getattribute__(k)
-        return super().__getitem__(k)
 
 
 @pytest.fixture(autouse=True)
@@ -80,8 +88,8 @@ def add_websockets_doctest_deps(doctest_namespace):
     TestChain = namedtuple('TestChain', ['blockNumber'])
     FakeFormatter = namedtuple('FakeFormatter', ['contract_event_name'])
     doctest_namespace['decoded_msg'] = lambda wsmsg: pprint(json.loads(wsmsg.decode('ascii')))
-    doctest_namespace["chain1"] = TestChain(117)
-    doctest_namespace["chain2"] = TestChain(220)
+    doctest_namespace["chain1"] = TestChain(mkevent.DEFAULT_BLOCK)
+    doctest_namespace["chain2"] = TestChain(mkevent.ALTERNATE_BLOCK)
     doctest_namespace["addr1"] = "0x00000000000000000000000000000001"
     doctest_namespace["addr2"] = "0x00000000000000000000000000000002"
     doctest_namespace["mkevent"] = mkevent

--- a/src/polyswarmd/websockets/filter.py
+++ b/src/polyswarmd/websockets/filter.py
@@ -122,7 +122,7 @@ class FilterManager:
     """Manages access to filtered Ethereum events."""
 
     def __init__(self):
-        self.wrappers = set()
+        self.wrappers = []
         self.pool = Group()
 
     def register(
@@ -130,7 +130,7 @@ class FilterManager:
     ):
         """Add a new filter, with an optional associated WebsocketMessage-serializer class"""
         wrapper = FilterWrapper(filter_installer, fmt_cls, backoff)
-        self.wrappers.add(wrapper)
+        self.wrappers.append(wrapper)
         logger.debug('Registered new filter: %s', wrapper)
 
     def flush(self):

--- a/src/polyswarmd/websockets/filter.py
+++ b/src/polyswarmd/websockets/filter.py
@@ -1,7 +1,6 @@
-from contextlib import contextmanager
 import logging
 from random import gauss
-from typing import Any, Callable, ClassVar, Iterable, List, NoReturn, Set, Type
+from typing import Any, Callable, ClassVar, Iterable, List, NoReturn, Type
 
 import gevent
 from gevent.pool import Group
@@ -30,6 +29,17 @@ class ContractFilter:
 FormatClass = Type[messages.WebsocketFilterMessage]
 Message = bytes
 FilterInstaller = Callable[[str], ContractFilter]
+
+
+class FilterManagerResetWarning(RuntimeWarning):
+
+    def __init__(self, wrappers: Iterable['FilterWrapper']):
+        message = (
+            "Attempted to initialize a FilterManager with existing filters: "
+            ', '.join(map(str, (hasattr(fw, 'filter') and fw.filter.filter_id for fw in wrappers)))
+        )
+        super().__init__(message)
+
 
 class FilterWrapper:
     """A utility class which wraps a contract filter with websocket-messaging features"""
@@ -133,11 +143,6 @@ class FilterManager:
         self.wrappers.append(wrapper)
         logger.debug('Registered new filter: %s', wrapper)
 
-    def flush(self):
-        """End all event polling, uninstall all filters and remove their corresponding wrappers"""
-        self.pool.kill()
-        self.wrappers.clear()
-
     def fetch(self):
         """Return a queue of currently managed contract events"""
         queue = Queue()
@@ -148,8 +153,7 @@ class FilterManager:
     def setup_event_filters(self, chain: Any):
         """Setup the most common event filters"""
         if len(self.wrappers) != 0:
-            logger.exception("Attempting to initialize already initialized filter manager")
-            self.flush()
+            raise FilterManagerResetWarning(self.wrappers)
 
         bounty_contract = chain.bounty_registry.contract
 

--- a/src/polyswarmd/websockets/json_schema.py
+++ b/src/polyswarmd/websockets/json_schema.py
@@ -1,6 +1,7 @@
 from functools import partial
 import operator
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -9,7 +10,6 @@ from typing import (
     List,
     Mapping,
     SupportsInt,
-    TYPE_CHECKING,
     Union,
     cast,
 )
@@ -25,7 +25,6 @@ SchemaType = str
 SchemaFormat = str
 SchemaExtraction = Dict[Any, Any]
 
-
 SchemaDef = TypedDict(
     'SchemaDef', {
         'type': 'SchemaType',
@@ -38,7 +37,6 @@ SchemaDef = TypedDict(
 )
 
 JSONSchema = TypedDict('JSONSchema', {'properties': Mapping[str, 'SchemaDef']}, total=False)
-
 
 
 def compose(f, g):

--- a/src/polyswarmd/websockets/json_schema.py
+++ b/src/polyswarmd/websockets/json_schema.py
@@ -19,7 +19,10 @@ import uuid
 if TYPE_CHECKING:
     from mypy_extensions import TypedDict
 else:
-    TypedDict = lambda *args, **kwargs: object
+
+    def TypedDict(*args, **kwargs):
+        return object
+
 
 SchemaType = str
 SchemaFormat = str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 """
    isort:skip_file
 """
-import random
 import os
 import pytest
 from unittest.mock import patch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,25 +58,46 @@ def client(app):
 @pytest.fixture(params=['home', 'side'], scope='session')
 def chain_config(request):
     return read_chain_cfg(request.param)
+
+
 @pytest.fixture(params=['home', 'side'], scope='session')
 def chains(request, app):
     return app.config['POLYSWARMD'].chains[request.param]
 
 
 @pytest.fixture
-def chain_id(): return 1337
+def chain_id():
+    return 1337
+
+
 @pytest.fixture(scope='session')
-def community(): return 'gamma'
+def community():
+    return 'gamma'
+
+
 @pytest.fixture(scope='session')
-def base_nonce(): return 1248924
+def base_nonce():
+    return 1248924
+
+
 @pytest.fixture
-def balances(token_address): return {token_address: 12345}
+def balances(token_address):
+    return {token_address: 12345}
+
+
 @pytest.fixture(scope='session')
-def token_address(): return '0x4B1867c484871926109E3C47668d5C0938CA3527'
+def token_address():
+    return '0x4B1867c484871926109E3C47668d5C0938CA3527'
+
+
 @pytest.fixture
-def gas_limit(): return 94040201
+def gas_limit():
+    return 94040201
+
+
 @pytest.fixture
-def block_number(token_address): return 5197
+def block_number(token_address):
+    return 5197
 
 
 @pytest.fixture
@@ -92,7 +113,6 @@ def bounty_parameters():
         'bounty_fee': 62500000000000000,
         'max_duration': 100
     }
-
 
 
 @pytest.fixture

--- a/tests/fixtures/config/polyswarmd/polyswarmd.yml
+++ b/tests/fixtures/config/polyswarmd/polyswarmd.yml
@@ -10,7 +10,7 @@ artifact:
 community: gamma
 eth:
   trace_transactions: true
-  directory: "/home/zv/polyswarm/polyswarmd/tests/fixtures/config/chain/"
+  directory: "tests/fixtures/config/chain/"
   # consul:
   #    uri: http://localhost:8500
 profiler:

--- a/tests/test_balances.py
+++ b/tests/test_balances.py
@@ -1,7 +1,7 @@
 from .utils import failed, heck
 
 
-def test_get_balance_total_stake(client, mock_w3, token_address, balances):
+def test_get_balance_total_stake(client, token_address, balances):
     assert client.get(f'/balances/{token_address}/staking/total').json == {
         'result': str(balances[token_address]),
         'status': 'OK'
@@ -10,7 +10,7 @@ def test_get_balance_total_stake(client, mock_w3, token_address, balances):
     assert failed(client.get(f'/balances/INVALID/staking/total'))
 
 
-def test_get_balance_withdrawable_stake(client, mock_w3, token_address, balances):
+def test_get_balance_withdrawable_stake(client, token_address, balances):
     assert client.get(f'/balances/{token_address}/staking/withdrawable').json == {
         'result': str(balances[token_address]),
         'status': 'OK'

--- a/tests/test_bounties.py
+++ b/tests/test_bounties.py
@@ -6,6 +6,6 @@ def test_get_bounties(client, token_address):
     assert response.json == heck({'result': heck.ARRAY, 'status': 'OK'})
 
 
-def test_get_bounties(mock_w3, client, token_address, bounty_parameters):
+def test_get_bounties(client, token_address, bounty_parameters):
     response = client.get('/bounties/parameters', query_string={'account': token_address})
     assert response.json == heck({'result': bounty_parameters, 'status': 'OK'})

--- a/tests/test_eth.py
+++ b/tests/test_eth.py
@@ -1,6 +1,6 @@
 from .utils import heck
 
 
-def test_get_nonce(client, mock_w3, token_address):
+def test_get_nonce(client, token_address):
     response = client.get('/nonce', query_string={'account': token_address}).json
     assert response == heck({'result': heck.UINT, 'status': 'OK'})

--- a/tests/test_event_message.py
+++ b/tests/test_event_message.py
@@ -1,6 +1,5 @@
 from collections.abc import Collection
 from contextlib import contextmanager
-from dataclasses import dataclass, field
 from math import ceil
 import pprint
 import statistics
@@ -49,14 +48,15 @@ class NOPMessage(WebsocketMessage):
     event: ClassVar[str] = 'nop'
 
 
-@dataclass
 class DumbFilter:
-    speed: float = field(default=1.0)
-    prev: int = field(default=0)
-    extra: Any = field(default_factory=dict)
-    start: Optional[float] = field(default=None)
-    backoff: bool = field(default=True)
-    ident: Optional[str] = field(default=None)
+    def __init__(self, speed=1.0, prev=0, extra={}, start=None, backoff=True, ident=None, source=None):
+        self.speed = speed
+        self.prev = prev
+        self.extra = extra
+        self.start = start
+        self.backoff = backoff
+        self.ident = ident
+        self.source = source
 
     # Verify that _something_ is being passed in, even if we're not using it.
     def __call__(self, contract_event_name):

--- a/tests/test_event_message.py
+++ b/tests/test_event_message.py
@@ -44,16 +44,13 @@ class NOPMessage(WebsocketMessage):
 class DumbFilter:
 
     def __init__(
-        self, speed=1.0, prev=0, extra={}, start=None, backoff=True, ident=None, source=None
+        self, speed=1.0, prev=0, extra={}, backoff=True, ident=None, source=None
     ):
         self.speed = (1/speed) * STRIDE
-        self.prev = prev
         self.extra = extra
         self.backoff = backoff
-        self._start = start
         self.ident = ident or str(uuid.uuid4())
         self.source = source or self.uniform(self.speed)
-        self.constructed = now()
 
     @property
     def start(self):
@@ -69,9 +66,7 @@ class DumbFilter:
         return {
             FILTER: self.ident,
             NTH: idx,
-            'step': step,
             TX_TS: now(),
-            'speed': self.speed,
             START: self.start,
             BACKOFF: self.backoff
         }

--- a/tests/test_event_message.py
+++ b/tests/test_event_message.py
@@ -79,12 +79,8 @@ class DumbFilter:
     def get_new_entries(self) -> Iterator:
         try:
             yield from next(self.source)
-        # XXX As of 01/17/20, `filter_manager` will continue to fetch events if all websockets
-        # disconnect, therefore this `StopIteration` handler won't surface issues which would arise
-        # from a future change to the code where `FilterManager` should die/`FilterManager.flush()`
-        # after `EthereumRpc.unregister()` or in a surrounding contextmanager
         except StopIteration:
-            yield tuple()
+            yield StopIteration
 
     def close(self):
         try:

--- a/tests/test_event_message.py
+++ b/tests/test_event_message.py
@@ -84,7 +84,7 @@ class DumbFilter:
         # from a future change to the code where `FilterManager` should die/`FilterManager.flush()`
         # after `EthereumRpc.unregister()` or in a surrounding contextmanager
         except StopIteration:
-            yield []
+            yield tuple()
 
     def close(self):
         try:

--- a/tests/test_event_message.py
+++ b/tests/test_event_message.py
@@ -51,6 +51,7 @@ class DumbFilter:
         self.backoff = backoff
         self.ident = ident or str(uuid.uuid4())
         self.source = source or self.uniform(self.speed)
+        self._start = None
 
     @property
     def start(self):

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -12,7 +12,7 @@ def tx_success_response(token_address, base_nonce):
     return heck({
         'result': {
             'transactions': [{
-                'chainId': heck.IGNORE,
+                'chainId': heck.SUBSTITUTE,
                 'data': lambda s: s[2:].startswith(TX_SIG_HASH) and len(s) > len(TX_SIG_HASH) + 32,
                 'gas': heck.POSINT,
                 'gasPrice': 0,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,14 +3,16 @@ This file contains utilities *FOR TESTING*, it should *NOT* contain tests of pol
 """
 from collections import UserDict
 from collections.abc import Collection, Mapping
+from curses.ascii import CAN as CANCEL
+from curses.ascii import SUB as SUBSTITUTE
 import json
 import string
 
 
 class heck(UserDict):
     """MappingProxy which allows functions as value to overide inner equality checks"""
-    IGNORE = b'\x03'
-    FAILED = b'\x15'
+    SUBSTITUTE = bytes([chr(SUBSTITUTE)])
+    FAILED = bytes([chr(CANCEL)])
 
     def __init__(self, data):
         if not isinstance(data, Mapping):
@@ -26,7 +28,7 @@ class heck(UserDict):
                 return [self.fixup(actual[i], expected[i]) for i, _ in enumerate(expected)]
         elif callable(expected):
             return actual if expected(actual) else self.FAILED
-        elif expected == self.IGNORE:
+        elif expected == self.SUBSTITUTE:
             return actual
         return expected
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,8 +11,8 @@ import string
 
 class heck(UserDict):
     """MappingProxy which allows functions as value to overide inner equality checks"""
-    SUBSTITUTE = bytes([chr(SUBSTITUTE)])
-    FAILED = bytes([chr(CANCEL)])
+    SUBSTITUTE = bytes([SUBSTITUTE])
+    FAILED = bytes([CANCEL])
 
     def __init__(self, data):
         if not isinstance(data, Mapping):


### PR DESCRIPTION
@Rizato found a batch of issues running the latest test suite on Python 3.6 & E2E state causing unit test failures,  which this PR addresses the root of.

In addition, it contains some quality of life patches to `gevent.sleep` & `web3.contract.Contract` to make tests almost instantaneous & entirely runnable without requesting any remote services. Finally, it has some automatic changes from `make format` and generating explicit exports through `__all__` in `__init__.py`


#### Changes

It is a bit chaotic (two 3-way merges from branches stashed on Jan 15th, with upstream changes!), but it doesn't contain much that needs serious review. It's changes are almost entirely limited to tests and those which aren't are all `make format`, automatic conversion of unnamed imports to `__all__` or [a change the warning which `FilterManager` when calling `setup_event_filter` on a previously initialized manager](https://github.com/polyswarm/polyswarmd/pull/280/files#diff-e3b5aa00f002d68d6d2feca0d0684358R156).

- Allow tests to run entirely in-container without foreign services
- Remove all 'SLOW' tests, running Websocket test code from a mock source.
- Return the gevent.sleep function as a unittest.mock.Mock
- Add short notes on each function's intention
- Let `enrich` inherit from `collections.UserList`
- Remove all 'wait' logic, just read directly from a generator
- Convert all time values to milliseconds-since-start
- Check that we're recieving the `contract_event_message` we expected
- Check that we're calling all the RPC & FilterManager methods once
- Verify that the structure of the EventMessage is correct in `enrich`
- Raise warning for re-initializing an existing FilterManager 
- Ran `make format` and autoextract to `__all__` from `__init__.py` without it