### PR TITLE
Call setup_event_filters only once

### DIFF
--- a/src/polyswarmd/services/ethereum/rpc.py
+++ b/src/polyswarmd/services/ethereum/rpc.py
@@ -65,7 +65,8 @@ class EthereumRpc:
             # if the greenlet is killed, we need to destroy the websocket connections (if any exist)
             with self.websockets_lock:
                 logger.exception(
-                    'Exiting poll() Greenlet with %d connected clients websockets', len(self.websockets)
+                    'Exiting poll() Greenlet with %d connected clients websockets',
+                    len(self.websockets)
                 )
                 self.websockets.clear()
         except Exception:

--- a/src/polyswarmd/services/ethereum/rpc.py
+++ b/src/polyswarmd/services/ethereum/rpc.py
@@ -16,11 +16,13 @@ class EthereumRpc:
     """
     This class periodically polls several geth filters, and multicasts the results across any open WebSockets
     """
+    filter_manager: FilterManager
     websockets: Optional[List[WebSocket]]
     websockets_lock: BoundedSemaphore
 
     def __init__(self, chain):
         self.chain = chain
+        self.filter_manager = FilterManager()
         self.websockets = None
         self.websockets_lock = BoundedSemaphore(1)
         self.chain = chain
@@ -50,31 +52,27 @@ class EthereumRpc:
         """
         Continually poll all Ethereum filters as long as there are WebSockets listening
         """
-        filter_manager = FilterManager()
-        filter_manager.setup_event_filters(self.chain)
         # Start the pool
         try:
-            for filter_events in filter_manager.fetch():
+            for filter_events in self.filter_manager.fetch():
                 for msg in filter_events:
                     self.broadcast(msg)
         except WebsocketConnectionAbortedError:
             logger.exception("Shutting down poll()")
             with self.websockets_lock:
-                self.websockets = None
+                self.websockets.clear()
         except gevent.GreenletExit:
             # if the greenlet is killed, we need to destroy the websocket connections (if any exist)
             with self.websockets_lock:
                 logger.exception(
                     'Exiting poll() Greenlet with %d connected clients websockets', len(self.websockets)
                 )
-                self.websockets = None
+                self.websockets.clear()
         except Exception:
             logger.exception(
                 'Exception in filter checks with %d connected websockets', len(self.websockets)
             )
-            # Creates a new greenlet with all new filters and let's this one die.
-            greenlet = gevent.spawn(self.poll)
-            gevent.signal(SIGQUIT, greenlet.kill)
+            self.start()
 
     def register(self, ws: WebSocket):
         """
@@ -87,10 +85,18 @@ class EthereumRpc:
             if self.websockets is None:
                 self.websockets = [ws]
                 logger.debug('First WebSocket registered, starting greenlet')
-                greenlet = gevent.spawn(self.poll)
-                gevent.signal(SIGQUIT, greenlet.kill)
+                self.filter_manager.setup_event_filters(self.chain)
+                self.start()
+            elif not self.websockets:
+                self.filter_manager.flush()
+                self.websockets.append(ws)
+                self.start()
             else:
                 self.websockets.append(ws)
+
+    def start(self):
+        greenlet = gevent.spawn(self.poll)
+        gevent.signal(SIGQUIT, greenlet.kill)
 
     def unregister(self, ws: WebSocket):
         """

--- a/src/polyswarmd/websockets/filter.py
+++ b/src/polyswarmd/websockets/filter.py
@@ -152,7 +152,7 @@ class FilterManager:
 
     def flush(self):
         for wrapper in self.wrappers:
-            wrapper.get_new_entries()
+            wrapper.filter.get_new_entries()
 
     def setup_event_filters(self, chain: Any):
         """Setup the most common event filters"""

--- a/src/polyswarmd/websockets/filter.py
+++ b/src/polyswarmd/websockets/filter.py
@@ -150,6 +150,10 @@ class FilterManager:
             self.pool.spawn(wrapper.spawn_poll_loop, queue.put_nowait)
         yield from queue
 
+    def flush(self):
+        for wrapper in self.wrappers:
+            wrapper.get_new_entries()
+
     def setup_event_filters(self, chain: Any):
         """Setup the most common event filters"""
         if len(self.wrappers) != 0:

--- a/src/polyswarmd/websockets/messages.py
+++ b/src/polyswarmd/websockets/messages.py
@@ -147,7 +147,8 @@ class MetadataHandler:
         cls._substitute_metadata = _substitute_metadata_impl
 
     @classmethod
-    def fetch(cls, msg: WebsocketEventMessage[D],
+    def fetch(cls,
+              msg: WebsocketEventMessage[D],
               validate=AssertionMetadata.validate) -> WebsocketEventMessage[D]:
         """Fetch metadata with URI from `msg', validate it and merge the result"""
         data = msg.get('data')

--- a/tests/test_event_message.py
+++ b/tests/test_event_message.py
@@ -2,9 +2,9 @@ from collections import UserList
 from contextlib import contextmanager
 from curses.ascii import EOT as END_OF_TRANSMISSION
 import statistics
+from string import ascii_lowercase
 import time
 from typing import ClassVar, Generator, Iterator, List, Mapping
-from string import ascii_lowercase
 import unittest.mock
 import uuid
 


### PR DESCRIPTION
When all websockets disconnected and a new one connected, we were seeing `FilterManagerResetWarning` as `setup_event_filters` was called again on the same `FilterManager`.

1. `self.websockets` is cleared instead of set to None on disconnects/errors. This lets the register function decide whether or not to call setup_event_filters with the 'first' connection. 
2. `FilterManager.flush()` allows the whole set of old events to be cleared from the queue on 'first' websocket after all disconnects. 