### PR TITLE
[WIP] PROPOSAL: Hand event messages to a `rpc.py` callback directly

### DIFF
--- a/src/polyswarmd/websockets/filter.py
+++ b/src/polyswarmd/websockets/filter.py
@@ -12,25 +12,6 @@ from . import messages
 logger = logging.getLogger(__name__)
 
 
-class ContractFilter:
-    callbacks: List[Callable[..., Any]]
-    stopped: bool
-    poll_interval: float
-    filter_id: int
-    web3: Any
-
-    def get_new_entries(self) -> List[messages.EventData]:
-        ...
-
-    def get_all_entries(self) -> List[messages.EventData]:
-        ...
-
-
-FormatClass = Type[messages.WebsocketFilterMessage]
-Message = bytes
-FilterInstaller = Callable[[str], ContractFilter]
-
-
 class FilterWrapper:
     """A utility class which wraps a contract filter with websocket-messaging features"""
     filter: ContractFilter
@@ -79,7 +60,7 @@ class FilterWrapper:
             return self.MIN_WAIT
 
     def get_new_entries(self) -> List[Message]:
-        return [self.formatter.serialize_message(e) for e in self.filter.get_new_entries()]
+        return self.filter.get_new_entries()
 
     def spawn_poll_loop(self, callback: Callable[[Iterable[Message]], NoReturn]):
         """Spawn a greenlet which polls the filter's contract events, passing results to `callback'"""
@@ -112,7 +93,7 @@ class FilterWrapper:
             # Reset the ctr if we received a non-empty response or we shouldn't backoff
             if len(result) != 0:
                 ctr = 0
-                callback(result)
+                callback(map(self.formatter.serialize_message, result))
 
             wait = self.compute_wait(ctr)
             logger.debug("%s wait=%f", self.filter, wait)
@@ -140,34 +121,26 @@ class FilterManager:
             self.pool.spawn(wrapper.spawn_poll_loop, queue.put_nowait)
         yield from queue
 
-    def setup_event_filters(self, chain: Any):
-        """Setup the most common event filters"""
-        if len(self.wrappers) != 0:
-            logger.warning("Attempted to initialize a FilterManager with existing filters: ", self.wrappers)
-            return
+    def pipe_events(self, broadcast_fn):
+        """Return a queue of currently managed contract events"""
+        for wrapper in self.wrappers:
+            self.pool.spawn(wrapper.spawn_poll_loop, broadcast_fn)
 
-        bounty_contract = chain.bounty_registry.contract
 
-        # Setup Latest (although this could pass `w3.eth.filter` directly)
-        self.register(chain.w3.eth.filter, messages.LatestEvent.make(chain.w3.eth), backoff=False)
-        # messages.NewBounty shouldn't wait or back-off from new bounties.
-        self.register(bounty_contract.eventFilter, messages.NewBounty, backoff=False)
+class ContractFilter:
+    callbacks: List[Callable[..., Any]]
+    stopped: bool
+    poll_interval: float
+    filter_id: int
+    web3: Any
 
-        filter_events: List[FormatClass] = [
-            messages.FeesUpdated,
-            messages.WindowsUpdated,
-            messages.NewAssertion,
-            messages.NewVote,
-            messages.QuorumReached,
-            messages.SettledBounty,
-            messages.RevealedAssertion,
-            messages.Deprecated,
-            messages.Undeprecated,
-        ]
+    def get_new_entries(self) -> List[messages.EventData]:
+        ...
 
-        for cls in filter_events:
-            self.register(bounty_contract.eventFilter, cls)
+    def get_all_entries(self) -> List[messages.EventData]:
+        ...
 
-        offer_registry = chain.offer_registry
-        if offer_registry and offer_registry.contract:
-            self.register(offer_registry.contract.eventFilter, messages.InitializedChannel)
+
+FormatClass = Type[messages.WebsocketFilterMessage]
+Message = bytes
+FilterInstaller = Callable[[str], ContractFilter]

--- a/src/polyswarmd/websockets/filter.py
+++ b/src/polyswarmd/websockets/filter.py
@@ -31,16 +31,6 @@ Message = bytes
 FilterInstaller = Callable[[str], ContractFilter]
 
 
-class FilterManagerResetWarning(RuntimeWarning):
-
-    def __init__(self, wrappers: Iterable['FilterWrapper']):
-        message = (
-            "Attempted to initialize a FilterManager with existing filters: "
-            ', '.join(map(str, (hasattr(fw, 'filter') and fw.filter.filter_id for fw in wrappers)))
-        )
-        super().__init__(message)
-
-
 class FilterWrapper:
     """A utility class which wraps a contract filter with websocket-messaging features"""
     filter: ContractFilter
@@ -153,7 +143,8 @@ class FilterManager:
     def setup_event_filters(self, chain: Any):
         """Setup the most common event filters"""
         if len(self.wrappers) != 0:
-            raise FilterManagerResetWarning(self.wrappers)
+            logger.warning("Attempted to initialize a FilterManager with existing filters: ", self.wrappers)
+            return
 
         bounty_contract = chain.bounty_registry.contract
 

--- a/tests/test_event_message.py
+++ b/tests/test_event_message.py
@@ -2,9 +2,9 @@ from collections import UserList
 from contextlib import contextmanager
 from curses.ascii import EOT as END_OF_TRANSMISSION
 import statistics
+from string import ascii_lowercase
 import time
 from typing import ClassVar, Generator, Iterator, List, Mapping
-from string import ascii_lowercase
 import unittest.mock
 import uuid
 


### PR DESCRIPTION
 PROPOSAL: Hand event messages to a `rpc.py` callback directly

This change does have a few advantages over the existing concept:

- No work is performed in serialization if there are no messages to be serialized
- The filter manager is kept alive, even after disconnect of the last client
- Tons of code responsible for handling the queue can be trashed

